### PR TITLE
Define HttpClient trait and response types

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1142,6 +1142,7 @@ checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
 name = "educartable-sync"
 version = "0.10.0"
 dependencies = [
+ "async-trait",
  "keyring",
  "log",
  "mockito",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -34,6 +34,7 @@ reqwest = { version = "0.12", features = ["json"] }
 tokio = { version = "1", features = ["full"] }
 keyring = "2"
 log = "0.4"
+async-trait = "0.1"
 
 [dev-dependencies]
 tokio = { version = "1", features = ["full", "test-util", "macros"] }

--- a/src-tauri/src/api.rs
+++ b/src-tauri/src/api.rs
@@ -1,8 +1,55 @@
 // API client for Educartable endpoints
 use crate::auth;
 use crate::models::{ActivitiesResponse, Activity, UserInfo, UserInfoResponse};
+use async_trait::async_trait;
 use reqwest::Client;
 use serde::Deserialize;
+use std::collections::HashMap;
+
+/// Simple HTTP response abstraction
+#[allow(dead_code)]
+pub struct HttpResponse {
+    pub status: u16,
+    pub headers: HashMap<String, String>,
+    pub body: Vec<u8>,
+}
+
+#[allow(dead_code)]
+impl HttpResponse {
+    /// Parse the response body as JSON
+    pub fn json<T: for<'de> Deserialize<'de>>(
+        &self,
+    ) -> Result<T, Box<dyn std::error::Error + Send + Sync>> {
+        serde_json::from_slice(&self.body).map_err(|e| e.into())
+    }
+
+    /// Convert the response body to a UTF-8 string
+    pub fn text(&self) -> Result<String, Box<dyn std::error::Error + Send + Sync>> {
+        String::from_utf8(self.body.clone()).map_err(|e| e.into())
+    }
+
+    /// Check if the response status indicates success (2xx)
+    pub fn is_success(&self) -> bool {
+        self.status >= 200 && self.status < 300
+    }
+
+    /// Check if the response status indicates a redirection (3xx)
+    pub fn is_redirection(&self) -> bool {
+        self.status >= 300 && self.status < 400
+    }
+}
+
+/// Trait for abstracting HTTP client operations
+#[allow(dead_code)]
+#[async_trait]
+pub trait HttpClient: Send + Sync {
+    /// Perform a GET request with headers
+    async fn get(
+        &self,
+        url: &str,
+        headers: Vec<(&str, &str)>,
+    ) -> Result<HttpResponse, Box<dyn std::error::Error + Send + Sync>>;
+}
 
 pub struct EducartableClient {
     client: Client,
@@ -186,6 +233,136 @@ mod tests {
         let client = EducartableClient::new();
         // Verify the client struct exists (compilation test)
         drop(client);
+    }
+
+    // ========== HttpResponse Tests ==========
+
+    #[test]
+    fn test_http_response_json() {
+        let json_body = r#"{"id": 123, "name": "test"}"#;
+        let response = HttpResponse {
+            status: 200,
+            headers: HashMap::new(),
+            body: json_body.as_bytes().to_vec(),
+        };
+
+        #[derive(Deserialize, Debug, PartialEq)]
+        struct TestData {
+            id: i32,
+            name: String,
+        }
+
+        let parsed: TestData = response.json().unwrap();
+        assert_eq!(parsed.id, 123);
+        assert_eq!(parsed.name, "test");
+    }
+
+    #[test]
+    fn test_http_response_text() {
+        let text_body = "Hello, World!";
+        let response = HttpResponse {
+            status: 200,
+            headers: HashMap::new(),
+            body: text_body.as_bytes().to_vec(),
+        };
+
+        let text = response.text().unwrap();
+        assert_eq!(text, "Hello, World!");
+    }
+
+    #[test]
+    fn test_http_response_is_success() {
+        let response_200 = HttpResponse {
+            status: 200,
+            headers: HashMap::new(),
+            body: Vec::new(),
+        };
+        assert!(response_200.is_success());
+
+        let response_201 = HttpResponse {
+            status: 201,
+            headers: HashMap::new(),
+            body: Vec::new(),
+        };
+        assert!(response_201.is_success());
+
+        let response_299 = HttpResponse {
+            status: 299,
+            headers: HashMap::new(),
+            body: Vec::new(),
+        };
+        assert!(response_299.is_success());
+
+        let response_404 = HttpResponse {
+            status: 404,
+            headers: HashMap::new(),
+            body: Vec::new(),
+        };
+        assert!(!response_404.is_success());
+    }
+
+    #[test]
+    fn test_http_response_is_redirection() {
+        let response_302 = HttpResponse {
+            status: 302,
+            headers: HashMap::new(),
+            body: Vec::new(),
+        };
+        assert!(response_302.is_redirection());
+
+        let response_301 = HttpResponse {
+            status: 301,
+            headers: HashMap::new(),
+            body: Vec::new(),
+        };
+        assert!(response_301.is_redirection());
+
+        let response_200 = HttpResponse {
+            status: 200,
+            headers: HashMap::new(),
+            body: Vec::new(),
+        };
+        assert!(!response_200.is_redirection());
+
+        let response_404 = HttpResponse {
+            status: 404,
+            headers: HashMap::new(),
+            body: Vec::new(),
+        };
+        assert!(!response_404.is_redirection());
+    }
+
+    #[test]
+    fn test_http_response_invalid_json() {
+        let invalid_json = "not valid json";
+        let response = HttpResponse {
+            status: 200,
+            headers: HashMap::new(),
+            body: invalid_json.as_bytes().to_vec(),
+        };
+
+        #[derive(Deserialize)]
+        #[allow(dead_code)]
+        struct TestData {
+            id: i32,
+            name: String,
+        }
+
+        let result: Result<TestData, _> = response.json();
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_http_response_invalid_utf8() {
+        let invalid_utf8 = vec![0xff, 0xfe, 0xfd]; // Invalid UTF-8 sequence
+        let response = HttpResponse {
+            status: 200,
+            headers: HashMap::new(),
+            body: invalid_utf8,
+        };
+
+        let result = response.text();
+        assert!(result.is_err());
     }
 
     // ========== URL Construction Tests ==========


### PR DESCRIPTION
## Summary

This PR implements the foundational abstraction layer for HTTP operations by defining the `HttpClient` trait and `HttpResponse` struct. This is the first step in refactoring the API client to support dependency injection and enable comprehensive testing without real HTTP requests.

## Changes

- **Added `async-trait` dependency** to Cargo.toml for async trait methods
- **Defined `HttpResponse` struct** - A simple HTTP response abstraction with:
  - `status`: HTTP status code (u16)
  - `headers`: Response headers (HashMap)
  - `body`: Response body (Vec<u8>)
  - Helper methods: `json()`, `text()`, `is_success()`, `is_redirection()`
- **Defined `HttpClient` trait** - Async trait for abstracting HTTP operations:
  - `get()` method for performing GET requests with headers
- **Added comprehensive unit tests** for all `HttpResponse` methods:
  - JSON parsing (valid and invalid)
  - Text conversion (valid and invalid UTF-8)
  - Status code checking (success and redirection)

## Testing

All 6 new tests pass:
- `test_http_response_json`
- `test_http_response_text`
- `test_http_response_is_success`
- `test_http_response_is_redirection`
- `test_http_response_invalid_json`
- `test_http_response_invalid_utf8`

All existing tests continue to pass (108 passed, 28 ignored).

## Notes

- The `HttpResponse` struct and `HttpClient` trait are marked with `#[allow(dead_code)]` as they will be used in the next issues (#71, #72).
- The trait and struct are public to enable usage across modules.

## Related Issues

Part of #68
Closes #70

## Next Steps

- #71: Create ReqwestHttpClient implementation
- #72: Refactor EducartableClient to use HttpClient trait