### PR TITLE
feat: implement ReqwestHttpClient for HttpClient trait

### DIFF
--- a/src-tauri/src/api.rs
+++ b/src-tauri/src/api.rs
@@ -51,6 +51,65 @@ pub trait HttpClient: Send + Sync {
     ) -> Result<HttpResponse, Box<dyn std::error::Error + Send + Sync>>;
 }
 
+/// Implementation of HttpClient using reqwest
+#[allow(dead_code)]
+pub struct ReqwestHttpClient {
+    client: Client,
+}
+
+#[allow(dead_code)]
+impl ReqwestHttpClient {
+    /// Create a new ReqwestHttpClient with a default reqwest::Client
+    pub fn new() -> Self {
+        Self {
+            client: Client::new(),
+        }
+    }
+
+    /// Create a new ReqwestHttpClient with an existing reqwest::Client
+    pub fn with_client(client: Client) -> Self {
+        Self { client }
+    }
+}
+
+#[async_trait]
+impl HttpClient for ReqwestHttpClient {
+    async fn get(
+        &self,
+        url: &str,
+        headers: Vec<(&str, &str)>,
+    ) -> Result<HttpResponse, Box<dyn std::error::Error + Send + Sync>> {
+        // Build the request with headers
+        let mut request_builder = self.client.get(url);
+        for (key, value) in headers {
+            request_builder = request_builder.header(key, value);
+        }
+
+        // Send the request
+        let response = request_builder.send().await?;
+
+        // Extract status code
+        let status = response.status().as_u16();
+
+        // Extract headers and convert to HashMap<String, String>
+        let mut response_headers = HashMap::new();
+        for (name, value) in response.headers().iter() {
+            let header_name = name.as_str().to_string();
+            let header_value = value.to_str().unwrap_or("").to_string();
+            response_headers.insert(header_name, header_value);
+        }
+
+        // Extract body as Vec<u8>
+        let body = response.bytes().await?.to_vec();
+
+        Ok(HttpResponse {
+            status,
+            headers: response_headers,
+            body,
+        })
+    }
+}
+
 pub struct EducartableClient {
     client: Client,
 }


### PR DESCRIPTION
## Summary

Implements the `ReqwestHttpClient` struct as a concrete implementation of the `HttpClient` trait using the `reqwest` crate. This implementation:

- Provides a `ReqwestHttpClient` struct that wraps a `reqwest::Client`
- Implements the `HttpClient` trait's `get` method
- Handles HTTP requests with custom headers
- Converts `reqwest::Response` to `HttpResponse` (status, headers, body)

## Implementation Details

- Added `ReqwestHttpClient::new()` constructor for creating a default client
- Added `ReqwestHttpClient::with_client()` for dependency injection
- Properly converts response headers to `HashMap<String, String>`
- Uses `.to_str().unwrap_or("")` for safe non-UTF8 header value handling
- Extracts response body as `Vec<u8>`

## Test Plan

- [x] Code compiles without errors
- [x] All existing tests pass (16 passed)
- [x] Clippy runs without warnings
- [x] Pre-commit hooks pass successfully

Part of #68
Closes #71