### PR TITLE
Refactor EducartableClient to use HttpClient trait

### DIFF
--- a/src-tauri/src/api.rs
+++ b/src-tauri/src/api.rs
@@ -5,6 +5,7 @@ use async_trait::async_trait;
 use reqwest::Client;
 use serde::Deserialize;
 use std::collections::HashMap;
+use std::sync::Arc;
 
 /// Simple HTTP response abstraction
 #[allow(dead_code)]
@@ -70,6 +71,14 @@ impl ReqwestHttpClient {
     pub fn with_client(client: Client) -> Self {
         Self { client }
     }
+
+    /// Create a new ReqwestHttpClient that doesn't follow redirects
+    pub fn new_no_redirect() -> Result<Self, Box<dyn std::error::Error + Send + Sync>> {
+        let client = Client::builder()
+            .redirect(reqwest::redirect::Policy::none())
+            .build()?;
+        Ok(Self { client })
+    }
 }
 
 #[async_trait]
@@ -110,15 +119,15 @@ impl HttpClient for ReqwestHttpClient {
     }
 }
 
-pub struct EducartableClient {
-    client: Client,
+pub struct EducartableClient<H: HttpClient> {
+    http_client: Arc<H>,
 }
 
-impl EducartableClient {
-    pub fn new() -> Self {
+impl<H: HttpClient> EducartableClient<H> {
+    pub fn new(http_client: H) -> Self {
         log::debug!("Creating new EducartableClient");
         Self {
-            client: Client::new(),
+            http_client: Arc::new(http_client),
         }
     }
 
@@ -135,27 +144,33 @@ impl EducartableClient {
 
         let access_token = self.get_access_token().await?;
 
-        let response = self
-            .client
-            .get(url)
-            .header("Authorization", &access_token) // NO "Bearer"!
-            .header("Accept", "application/json")
-            .header("Content-Type", "application/json")
-            .header("X-Edumoov-NoSession", "true")
-            .send()
-            .await?;
+        let headers = vec![
+            ("Authorization", access_token.as_str()), // NO "Bearer"!
+            ("Accept", "application/json"),
+            ("Content-Type", "application/json"),
+            ("X-Edumoov-NoSession", "true"),
+        ];
 
-        let status = response.status();
-        log::debug!("Response status: {}", status);
+        let response = self.http_client.get(url, headers).await?;
 
-        if !status.is_success() {
+        log::debug!("Response status: {}", response.status);
+
+        if !response.is_success() {
             // Get the error response body for debugging
-            let error_body = response.text().await?;
-            log::error!("Request failed with status {}: {}", status, error_body);
-            return Err(format!("Request failed with status {}: {}", status, error_body).into());
+            let error_body = response.text()?;
+            log::error!(
+                "Request failed with status {}: {}",
+                response.status,
+                error_body
+            );
+            return Err(format!(
+                "Request failed with status {}: {}",
+                response.status, error_body
+            )
+            .into());
         }
 
-        let data: T = response.json().await?;
+        let data: T = response.json()?;
         log::debug!("Response parsed successfully");
         Ok(data)
     }
@@ -169,23 +184,21 @@ impl EducartableClient {
 
         let access_token = self.get_access_token().await?;
 
-        let response = self
-            .client
-            .get(url)
-            .header("Authorization", &access_token)
-            .send()
-            .await?;
+        let headers = vec![("Authorization", access_token.as_str())];
 
-        let status = response.status();
-        log::debug!("User info response status: {}", status);
+        let response = self.http_client.get(url, headers).await?;
 
-        if !status.is_success() {
-            log::error!("User info request failed with status: {}", status);
-            return Err(format!("User info request failed with status: {}", status).into());
+        log::debug!("User info response status: {}", response.status);
+
+        if !response.is_success() {
+            log::error!("User info request failed with status: {}", response.status);
+            return Err(
+                format!("User info request failed with status: {}", response.status).into(),
+            );
         }
 
         // Parse the response wrapper and extract the data field
-        let response_wrapper: UserInfoResponse = response.json().await?;
+        let response_wrapper: UserInfoResponse = response.json()?;
 
         log::info!(
             "User info fetched successfully for user ID: {}",
@@ -247,24 +260,22 @@ impl EducartableClient {
         let access_token = self.get_access_token().await?;
 
         // Disable automatic redirect following to capture the Location header
-        let response = Client::builder()
-            .redirect(reqwest::redirect::Policy::none())
-            .build()?
-            .get(&url)
-            .header("Authorization", &access_token)
-            .send()
-            .await?;
+        // Create a temporary no-redirect client for this request
+        let no_redirect_client = ReqwestHttpClient::new_no_redirect()?;
 
-        let status = response.status();
-        log::debug!("Signed URL response status: {}", status);
+        let headers = vec![("Authorization", access_token.as_str())];
+
+        let response = no_redirect_client.get(&url, headers).await?;
+
+        log::debug!("Signed URL response status: {}", response.status);
 
         // Extract Location header from 302 redirect
-        if status.is_redirection() {
+        if response.is_redirection() {
             let location = response
-                .headers()
-                .get("Location")
+                .headers
+                .get("location")
+                .or_else(|| response.headers.get("Location"))
                 .ok_or("No Location header in redirect")?
-                .to_str()?
                 .to_string();
 
             log::debug!("Signed URL obtained for {}", filename);
@@ -273,10 +284,21 @@ impl EducartableClient {
             log::error!(
                 "Expected redirect response for {}, got status: {}",
                 filename,
-                status
+                response.status
             );
-            Err(format!("Expected redirect response, got status: {}", status).into())
+            Err(format!(
+                "Expected redirect response, got status: {}",
+                response.status
+            )
+            .into())
         }
+    }
+}
+
+// Convenience constructor for production code using ReqwestHttpClient
+impl EducartableClient<ReqwestHttpClient> {
+    pub fn new_default() -> Self {
+        Self::new(ReqwestHttpClient::new())
     }
 }
 
@@ -289,7 +311,7 @@ mod tests {
     #[test]
     fn test_educartable_client_new() {
         // Test that client can be constructed
-        let client = EducartableClient::new();
+        let client = EducartableClient::new_default();
         // Verify the client struct exists (compilation test)
         drop(client);
     }

--- a/src-tauri/src/sync.rs
+++ b/src-tauri/src/sync.rs
@@ -230,14 +230,18 @@ fn is_retryable_error(error: &dyn std::error::Error) -> bool {
 }
 
 // Issue #26: Progress tracking with Tauri events
-pub struct SyncEngine {
+pub struct SyncEngine<H: crate::api::HttpClient> {
     app_handle: AppHandle,
-    api_client: EducartableClient,
+    api_client: EducartableClient<H>,
     sync_path: PathBuf,
 }
 
-impl SyncEngine {
-    pub fn new(app_handle: AppHandle, api_client: EducartableClient, sync_path: PathBuf) -> Self {
+impl<H: crate::api::HttpClient> SyncEngine<H> {
+    pub fn new(
+        app_handle: AppHandle,
+        api_client: EducartableClient<H>,
+        sync_path: PathBuf,
+    ) -> Self {
         log::debug!("Creating SyncEngine with sync_path: {:?}", sync_path);
         Self {
             app_handle,
@@ -417,7 +421,7 @@ pub async fn start_sync(
     log::info!("Sync directory: {:?}", config.sync_path);
 
     // Create API client (will fetch and refresh tokens automatically)
-    let api_client = EducartableClient::new();
+    let api_client = EducartableClient::new_default();
 
     // Create sync engine
     let sync_engine = SyncEngine::new(app_handle, api_client, config.sync_path);


### PR DESCRIPTION
## Summary

Refactors `EducartableClient` to use the `HttpClient` trait instead of directly using `reqwest::Client`, enabling dependency injection and better testability.

Part of #68
Implements #72

## Changes

### 1. Made EducartableClient Generic
- Changed from `EducartableClient` to `EducartableClient<H: HttpClient>`
- Replaced `client: Client` field with `http_client: Arc<H>`
- Uses `Arc` for efficient cloning and thread-safe sharing

### 2. Updated Constructor
```rust
impl<H: HttpClient> EducartableClient<H> {
    pub fn new(http_client: H) -> Self {
        Self { http_client: Arc::new(http_client) }
    }
}
```

### 3. Added Convenience Constructor
```rust
impl EducartableClient<ReqwestHttpClient> {
    pub fn new_default() -> Self {
        Self::new(ReqwestHttpClient::new())
    }
}
```

### 4. Refactored HTTP Methods
- `get<T>()`: Now uses `self.http_client.get()`
- `get_user_info()`: Uses abstracted HTTP client with headers as vector
- `get_signed_media_url()`: Uses `ReqwestHttpClient::new_no_redirect()` for special redirect handling

### 5. Enhanced ReqwestHttpClient
- Added `new_no_redirect()` method for creating clients that don't follow redirects
- Used for `get_signed_media_url()` which needs to capture redirect Location headers

### 6. Updated SyncEngine
- Made generic over `H: HttpClient`
- Updated constructor to accept `EducartableClient<H>`

### 7. Updated Instantiation Points
- Changed `EducartableClient::new()` to `EducartableClient::new_default()` in:
  - `src-tauri/src/sync.rs:424`
  - `src-tauri/src/api.rs` (tests)

## Testing

All checks passed:
- ✅ Compilation: `cargo build`
- ✅ Tests: 108/108 passing
- ✅ Clippy: No warnings
- ✅ Formatting: `cargo fmt` applied

## Design Decisions

1. **Arc for http_client**: Enables efficient cloning while sharing the same HTTP client instance
2. **Special redirect handling**: Instead of complicating the `HttpClient` trait, added `new_no_redirect()` to `ReqwestHttpClient` for the special case in `get_signed_media_url()`
3. **Convenience constructor**: `new_default()` provides ergonomic instantiation for production code without exposing implementation details

## Next Steps

This refactoring enables:
- #73: Create MockHttpClient for testing
- #74-76: Implement mock-based tests for various endpoints