### PR TITLE
Create MockHttpClient for testing

### DIFF
--- a/src-tauri/src/api.rs
+++ b/src-tauri/src/api.rs
@@ -305,6 +305,60 @@ impl EducartableClient<ReqwestHttpClient> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::collections::VecDeque;
+    use std::sync::Mutex;
+
+    // ========== MockHttpClient Implementation ==========
+
+    pub struct MockHttpClient {
+        responses: Arc<Mutex<VecDeque<HttpResponse>>>,
+    }
+
+    impl MockHttpClient {
+        pub fn new() -> Self {
+            Self {
+                responses: Arc::new(Mutex::new(VecDeque::new())),
+            }
+        }
+
+        pub fn add_response(&self, status: u16, body: &str) {
+            let response = HttpResponse {
+                status,
+                headers: HashMap::new(),
+                body: body.as_bytes().to_vec(),
+            };
+            self.responses.lock().unwrap().push_back(response);
+        }
+
+        pub fn add_response_with_headers(
+            &self,
+            status: u16,
+            headers: HashMap<String, String>,
+            body: &str,
+        ) {
+            let response = HttpResponse {
+                status,
+                headers,
+                body: body.as_bytes().to_vec(),
+            };
+            self.responses.lock().unwrap().push_back(response);
+        }
+    }
+
+    #[async_trait]
+    impl HttpClient for MockHttpClient {
+        async fn get(
+            &self,
+            _url: &str,
+            _headers: Vec<(&str, &str)>,
+        ) -> Result<HttpResponse, Box<dyn std::error::Error + Send + Sync>> {
+            self.responses
+                .lock()
+                .unwrap()
+                .pop_front()
+                .ok_or_else(|| "No mock response available".into())
+        }
+    }
 
     // ========== Tests for EducartableClient ==========
 


### PR DESCRIPTION
## Summary

Implements issue #73 - Add MockHttpClient implementation for testing.

## Changes

- Added `MockHttpClient` struct in the test module of `src-tauri/src/api.rs`
- Implemented queue-based FIFO response system using `VecDeque`
- Added helper methods:
  - `new()` - Constructor
  - `add_response(status, body)` - Add simple mock response
  - `add_response_with_headers(status, headers, body)` - Add response with custom headers
- Implemented `HttpClient` trait for `MockHttpClient`

## Features

- Queue-based responses (FIFO)
- Support for custom headers (needed for redirect Location header testing)
- Simple API for test setup
- Thread-safe using `Arc<Mutex<VecDeque<HttpResponse>>>`

## Testing

- ✅ Code compiles with `cargo check`
- ✅ Passes `cargo fmt` formatting
- ✅ Passes `cargo clippy` linting

## Related Issues

- Closes #73
- Part of #68

## Test Plan

- [x] Verify code compiles
- [x] Verify cargo fmt passes
- [x] Verify cargo clippy passes
- [ ] Mock-based tests will be added in subsequent issues (#74, #75, #76)