### PR TITLE
Define CredentialStore trait (#77)

### DIFF
--- a/src-tauri/src/auth.rs
+++ b/src-tauri/src/auth.rs
@@ -7,6 +7,19 @@ use std::time::{Duration, SystemTime, UNIX_EPOCH};
 use tauri::webview::PageLoadEvent;
 use tauri::{AppHandle, WebviewUrl, WebviewWindowBuilder, Wry};
 
+/// Trait for storing, loading, and deleting credentials
+#[allow(dead_code)] // Trait will be implemented in subsequent issues
+pub trait CredentialStore: Send + Sync {
+    /// Store a credential with the given key and value
+    fn store(&self, key: &str, value: &str) -> Result<(), String>;
+
+    /// Load a credential by key
+    fn load(&self, key: &str) -> Result<String, String>;
+
+    /// Delete a credential by key
+    fn delete(&self, key: &str) -> Result<(), String>;
+}
+
 // Global state to store tokens during extraction
 static TOKEN_CHANNEL: Mutex<Option<mpsc::Sender<String>>> = Mutex::new(None);
 


### PR DESCRIPTION
## Summary

This PR implements issue #77, adding the `CredentialStore` trait to abstract credential storage operations. This is the first step in refactoring the auth module for better testability (issue #69).

## Changes

- Added `CredentialStore` trait in `src-tauri/src/auth.rs`
- Trait defines three methods: `store()`, `load()`, and `delete()`
- All methods use `Result<T, String>` for error handling
- Trait requires `Send + Sync` bounds for thread safety
- Temporarily includes `#[allow(dead_code)]` as trait will be implemented in subsequent issues

## Related Issues

- Resolves #77
- Part of #69

## Next Steps

The next issue to work on is #78, which will create the `KeyringCredentialStore` implementation of this trait.