### PR TITLE
Create MockCredentialStore for testing

### DIFF
--- a/src-tauri/src/auth.rs
+++ b/src-tauri/src/auth.rs
@@ -772,22 +772,30 @@ pub async fn is_authenticated() -> Result<bool, String> {
 mod tests {
     use super::*;
     use std::collections::HashMap;
-    use std::sync::Mutex;
+    use std::sync::{Arc, Mutex};
 
     // NOTE: These tests require access to the system keyring and are marked as #[ignore]
     // by default. They can be run manually with: cargo test -- --ignored
     // These tests may fail in headless CI environments without proper keyring setup.
 
     // Mock credential store for testing
-    struct MockCredentialStore {
-        storage: Mutex<HashMap<String, String>>,
+    pub struct MockCredentialStore {
+        storage: Arc<Mutex<HashMap<String, String>>>,
     }
 
     impl MockCredentialStore {
-        fn new() -> Self {
+        pub fn new() -> Self {
             Self {
-                storage: Mutex::new(HashMap::new()),
+                storage: Arc::new(Mutex::new(HashMap::new())),
             }
+        }
+
+        pub fn clear(&self) {
+            self.storage.lock().unwrap().clear();
+        }
+
+        pub fn contains_key(&self, key: &str) -> bool {
+            self.storage.lock().unwrap().contains_key(key)
         }
     }
 


### PR DESCRIPTION
## Summary

Implements `MockCredentialStore` for use in tests, part of #69.

## Changes

- Updated `MockCredentialStore` to use `Arc<Mutex<HashMap<String, String>>>` for thread-safe sharing
- Added helper methods `clear()` and `contains_key()` for test assertions
- Made struct and methods public for use across tests
- Updated imports to include `Arc` from `std::sync`

## Features

- In-memory HashMap storage
- Thread-safe with `Arc<Mutex<>>`
- Simple implementation suitable for testing logic above the store layer
- No chunking logic needed (that's tested in `KeyringCredentialStore`)

## Testing

- ✅ All existing tests pass, including `test_store_tokens_with_mock_credential_store`
- ✅ Code compiles without errors
- ✅ Pre-commit hooks (cargo fmt, clippy) pass

Closes #80