### PR TITLE
Remove unused legacy auth helper functions

### DIFF
--- a/src-tauri/src/auth.rs
+++ b/src-tauri/src/auth.rs
@@ -704,14 +704,6 @@ pub async fn refresh_access_token(
     Ok(tokens)
 }
 
-/// Refresh access token using the refresh token with the default KeyringCredentialStore
-/// Returns new AuthTokens with updated access_token, refresh_token, and expires_at
-#[allow(dead_code)]
-pub async fn refresh_access_token_default(refresh_token: &str) -> Result<AuthTokens, String> {
-    let store = KeyringCredentialStore::new();
-    refresh_access_token(&store, refresh_token).await
-}
-
 /// Get valid access token, refreshing if necessary
 /// This function should be used by API client to ensure tokens are always valid
 pub async fn get_valid_access_token(store: &dyn CredentialStore) -> Result<String, String> {
@@ -736,13 +728,6 @@ pub async fn get_valid_access_token(store: &dyn CredentialStore) -> Result<Strin
         log::debug!("Access token is still valid");
         Ok(tokens.access_token)
     }
-}
-
-/// Get valid access token with the default KeyringCredentialStore
-#[allow(dead_code)]
-pub async fn get_valid_access_token_default() -> Result<String, String> {
-    let store = KeyringCredentialStore::new();
-    get_valid_access_token(&store).await
 }
 
 /// Check if the user is authenticated (has valid tokens that can be refreshed)


### PR DESCRIPTION
## Summary

Removes two unused legacy functions from `auth.rs` that became obsolete after the refactoring to accept `CredentialStore` for testability:

- `refresh_access_token_default()` (auth.rs:709-713)
- `get_valid_access_token_default()` (auth.rs:742-746)

## Why Remove?

These "default" wrapper functions are never called anywhere in the codebase. After the recent refactoring (#94, #95) to accept `CredentialStore` parameters for better testability, all production code now uses:
- `refresh_access_token(&store, refresh_token)` instead of `refresh_access_token_default(refresh_token)`
- `get_valid_access_token(&store)` instead of `get_valid_access_token_default()`

Both functions were marked with `#[allow(dead_code)]`, confirming they were known to be unused.

## Changes

- ✅ Verified no references exist in the codebase
- ✅ Removed both functions and their documentation
- ✅ Code compiles successfully (`cargo check`)
- ✅ Pre-commit hooks passed (cargo fmt, clippy)

## Testing

All existing tests continue to pass as these functions were not used by any test code.