### PR TITLE
Clean up ignored tests: remove redundant tests and enable mock-based tests (#97)

### DIFF
--- a/src-tauri/src/api.rs
+++ b/src-tauri/src/api.rs
@@ -571,7 +571,6 @@ mod tests {
     // These tests require mockito to mock HTTP responses
 
     #[tokio::test]
-    #[ignore] // Requires system keyring access
     async fn test_get_user_info_success() {
         // Setup: Store test tokens for auth
         let tokens = crate::models::AuthTokens {
@@ -582,11 +581,9 @@ mod tests {
             session_state: "test_session".to_string(),
         };
 
-        // Store tokens - if this fails, skip the test
-        if auth::store_tokens_default(&tokens).is_err() {
-            eprintln!("Skipping test: unable to access system keyring");
-            return;
-        }
+        let credential_store = Arc::new(crate::auth::MockCredentialStore::new());
+        crate::auth::store_tokens(credential_store.as_ref(), &tokens)
+            .expect("Failed to store tokens");
 
         // Setup: Create mock HTTP client
         let mock_client = MockHttpClient::new();
@@ -596,8 +593,7 @@ mod tests {
         mock_client.add_response(200, response_body);
 
         // Test: Call get_user_info
-        let credential_store = Arc::new(crate::auth::KeyringCredentialStore::new());
-        let client = EducartableClient::new(mock_client, credential_store);
+        let client = EducartableClient::new(mock_client, credential_store.clone());
         let result = client.get_user_info().await;
 
         // Verify: Check the result
@@ -612,11 +608,10 @@ mod tests {
         assert_eq!(user_info.name, Some("Test User".to_string()));
 
         // Cleanup
-        let _ = auth::delete_tokens_default();
+        let _ = crate::auth::delete_tokens(credential_store.as_ref());
     }
 
     #[tokio::test]
-    #[ignore] // Requires system keyring access
     async fn test_get_user_info_unauthorized() {
         // Setup: Store test tokens for auth
         let tokens = crate::models::AuthTokens {
@@ -627,11 +622,9 @@ mod tests {
             session_state: "test_session".to_string(),
         };
 
-        // Store tokens - if this fails, skip the test
-        if auth::store_tokens_default(&tokens).is_err() {
-            eprintln!("Skipping test: unable to access system keyring");
-            return;
-        }
+        let credential_store = Arc::new(crate::auth::MockCredentialStore::new());
+        crate::auth::store_tokens(credential_store.as_ref(), &tokens)
+            .expect("Failed to store tokens");
 
         // Setup: Create mock HTTP client
         let mock_client = MockHttpClient::new();
@@ -640,8 +633,7 @@ mod tests {
         mock_client.add_response(401, "Unauthorized");
 
         // Test: Call get_user_info
-        let credential_store = Arc::new(crate::auth::KeyringCredentialStore::new());
-        let client = EducartableClient::new(mock_client, credential_store);
+        let client = EducartableClient::new(mock_client, credential_store.clone());
         let result = client.get_user_info().await;
 
         // Verify: Check that request failed with appropriate error
@@ -654,11 +646,10 @@ mod tests {
         );
 
         // Cleanup
-        let _ = auth::delete_tokens_default();
+        let _ = crate::auth::delete_tokens(credential_store.as_ref());
     }
 
     #[tokio::test]
-    #[ignore] // Requires system keyring access
     async fn test_get_activities_success() {
         // Setup: Store valid test tokens
         let now = std::time::SystemTime::now()
@@ -675,11 +666,9 @@ mod tests {
             session_state: "test_session".to_string(),
         };
 
-        // Store tokens - if this fails, skip the test
-        if crate::auth::store_tokens_default(&tokens).is_err() {
-            eprintln!("Skipping test: unable to access system keyring");
-            return;
-        }
+        let credential_store = Arc::new(crate::auth::MockCredentialStore::new());
+        crate::auth::store_tokens(credential_store.as_ref(), &tokens)
+            .expect("Failed to store tokens");
 
         // Create mock HTTP client
         let mock = MockHttpClient::new();
@@ -709,8 +698,7 @@ mod tests {
         mock.add_response(200, response_body);
 
         // Create client with mock
-        let credential_store = Arc::new(crate::auth::KeyringCredentialStore::new());
-        let client = EducartableClient::new(mock, credential_store);
+        let client = EducartableClient::new(mock, credential_store.clone());
 
         // Test
         let result = client.get_activities(12345).await;
@@ -725,11 +713,10 @@ mod tests {
         assert_eq!(response.pagination.page_count, 1);
 
         // Cleanup
-        let _ = crate::auth::delete_tokens_default();
+        let _ = crate::auth::delete_tokens(credential_store.as_ref());
     }
 
     #[tokio::test]
-    #[ignore] // Requires system keyring access
     async fn test_get_activities_empty() {
         // Setup: Store valid test tokens
         let now = std::time::SystemTime::now()
@@ -746,11 +733,9 @@ mod tests {
             session_state: "test_session".to_string(),
         };
 
-        // Store tokens - if this fails, skip the test
-        if crate::auth::store_tokens_default(&tokens).is_err() {
-            eprintln!("Skipping test: unable to access system keyring");
-            return;
-        }
+        let credential_store = Arc::new(crate::auth::MockCredentialStore::new());
+        crate::auth::store_tokens(credential_store.as_ref(), &tokens)
+            .expect("Failed to store tokens");
 
         // Create mock HTTP client
         let mock = MockHttpClient::new();
@@ -771,8 +756,7 @@ mod tests {
         mock.add_response(200, response_body);
 
         // Create client with mock
-        let credential_store = Arc::new(crate::auth::KeyringCredentialStore::new());
-        let client = EducartableClient::new(mock, credential_store);
+        let client = EducartableClient::new(mock, credential_store.clone());
 
         // Test
         let result = client.get_activities(12345).await;
@@ -787,11 +771,10 @@ mod tests {
         assert_eq!(response.pagination.count, 0);
 
         // Cleanup
-        let _ = crate::auth::delete_tokens_default();
+        let _ = crate::auth::delete_tokens(credential_store.as_ref());
     }
 
     #[tokio::test]
-    #[ignore] // Requires system keyring access
     async fn test_get_activities_server_error() {
         // Setup: Store valid test tokens
         let now = std::time::SystemTime::now()
@@ -808,11 +791,9 @@ mod tests {
             session_state: "test_session".to_string(),
         };
 
-        // Store tokens - if this fails, skip the test
-        if crate::auth::store_tokens_default(&tokens).is_err() {
-            eprintln!("Skipping test: unable to access system keyring");
-            return;
-        }
+        let credential_store = Arc::new(crate::auth::MockCredentialStore::new());
+        crate::auth::store_tokens(credential_store.as_ref(), &tokens)
+            .expect("Failed to store tokens");
 
         // Create mock HTTP client
         let mock = MockHttpClient::new();
@@ -822,8 +803,7 @@ mod tests {
         mock.add_response(500, response_body);
 
         // Create client with mock
-        let credential_store = Arc::new(crate::auth::KeyringCredentialStore::new());
-        let client = EducartableClient::new(mock, credential_store);
+        let client = EducartableClient::new(mock, credential_store.clone());
 
         // Test
         let result = client.get_activities(12345).await;
@@ -838,11 +818,10 @@ mod tests {
         );
 
         // Cleanup
-        let _ = crate::auth::delete_tokens_default();
+        let _ = crate::auth::delete_tokens(credential_store.as_ref());
     }
 
     #[tokio::test]
-    #[ignore] // Requires system keyring access
     async fn test_get_signed_media_url_redirect() {
         // Setup test tokens
         let tokens = crate::models::AuthTokens {
@@ -853,11 +832,9 @@ mod tests {
             session_state: "test_session".to_string(),
         };
 
-        // Store tokens - if this fails, skip the test
-        if auth::store_tokens_default(&tokens).is_err() {
-            eprintln!("Skipping test: unable to access system keyring");
-            return;
-        }
+        let credential_store = Arc::new(crate::auth::MockCredentialStore::new());
+        crate::auth::store_tokens(credential_store.as_ref(), &tokens)
+            .expect("Failed to store tokens");
 
         // Setup mock with 302 redirect and Location header
         let mock = MockHttpClient::new();
@@ -869,8 +846,7 @@ mod tests {
         mock.add_response_with_headers(302, headers, "");
 
         // Test
-        let credential_store = Arc::new(crate::auth::KeyringCredentialStore::new());
-        let client = EducartableClient::new(mock, credential_store);
+        let client = EducartableClient::new(mock, credential_store.clone());
         let result = client.get_signed_media_url("media123", "photo.jpg").await;
 
         // Verify
@@ -883,11 +859,10 @@ mod tests {
         assert_eq!(signed_url, "https://signed-url.com/media.jpg");
 
         // Cleanup
-        let _ = auth::delete_tokens_default();
+        let _ = crate::auth::delete_tokens(credential_store.as_ref());
     }
 
     #[tokio::test]
-    #[ignore] // Requires system keyring access
     async fn test_get_signed_media_url_no_location_header() {
         // Setup test tokens
         let tokens = crate::models::AuthTokens {
@@ -898,11 +873,9 @@ mod tests {
             session_state: "test_session".to_string(),
         };
 
-        // Store tokens - if this fails, skip the test
-        if auth::store_tokens_default(&tokens).is_err() {
-            eprintln!("Skipping test: unable to access system keyring");
-            return;
-        }
+        let credential_store = Arc::new(crate::auth::MockCredentialStore::new());
+        crate::auth::store_tokens(credential_store.as_ref(), &tokens)
+            .expect("Failed to store tokens");
 
         // Setup mock with 302 redirect but NO Location header
         let mock = MockHttpClient::new();
@@ -910,8 +883,7 @@ mod tests {
         mock.add_response_with_headers(302, headers, "");
 
         // Test
-        let credential_store = Arc::new(crate::auth::KeyringCredentialStore::new());
-        let client = EducartableClient::new(mock, credential_store);
+        let client = EducartableClient::new(mock, credential_store.clone());
         let result = client.get_signed_media_url("media123", "photo.jpg").await;
 
         // Verify
@@ -927,11 +899,10 @@ mod tests {
         );
 
         // Cleanup
-        let _ = auth::delete_tokens_default();
+        let _ = crate::auth::delete_tokens(credential_store.as_ref());
     }
 
     #[tokio::test]
-    #[ignore] // Requires system keyring access
     async fn test_get_signed_media_url_not_redirect() {
         // Setup test tokens
         let tokens = crate::models::AuthTokens {
@@ -942,19 +913,16 @@ mod tests {
             session_state: "test_session".to_string(),
         };
 
-        // Store tokens - if this fails, skip the test
-        if auth::store_tokens_default(&tokens).is_err() {
-            eprintln!("Skipping test: unable to access system keyring");
-            return;
-        }
+        let credential_store = Arc::new(crate::auth::MockCredentialStore::new());
+        crate::auth::store_tokens(credential_store.as_ref(), &tokens)
+            .expect("Failed to store tokens");
 
         // Setup mock with 200 response (not a redirect)
         let mock = MockHttpClient::new();
         mock.add_response(200, "OK");
 
         // Test
-        let credential_store = Arc::new(crate::auth::KeyringCredentialStore::new());
-        let client = EducartableClient::new(mock, credential_store);
+        let client = EducartableClient::new(mock, credential_store.clone());
         let result = client.get_signed_media_url("media123", "photo.jpg").await;
 
         // Verify
@@ -967,11 +935,10 @@ mod tests {
         );
 
         // Cleanup
-        let _ = auth::delete_tokens_default();
+        let _ = crate::auth::delete_tokens(credential_store.as_ref());
     }
 
     #[tokio::test]
-    #[ignore] // Requires system keyring access
     async fn test_fetch_all_activities_integration() {
         // Setup: Store valid test tokens
         let now = std::time::SystemTime::now()
@@ -988,11 +955,9 @@ mod tests {
             session_state: "test_session".to_string(),
         };
 
-        // Store tokens - if this fails, skip the test
-        if crate::auth::store_tokens_default(&tokens).is_err() {
-            eprintln!("Skipping test: unable to access system keyring");
-            return;
-        }
+        let credential_store = Arc::new(crate::auth::MockCredentialStore::new());
+        crate::auth::store_tokens(credential_store.as_ref(), &tokens)
+            .expect("Failed to store tokens");
 
         // Create mock HTTP client
         let mock = MockHttpClient::new();
@@ -1061,8 +1026,7 @@ mod tests {
         mock.add_response(200, response_body);
 
         // Create client with mock
-        let credential_store = Arc::new(crate::auth::KeyringCredentialStore::new());
-        let client = EducartableClient::new(mock, credential_store);
+        let client = EducartableClient::new(mock, credential_store.clone());
 
         // Test fetch_all_activities
         let result = client.fetch_all_activities(12345).await;
@@ -1094,7 +1058,7 @@ mod tests {
         assert_eq!(activities[2].pupils, vec![1, 2, 3]);
 
         // Cleanup
-        let _ = crate::auth::delete_tokens_default();
+        let _ = crate::auth::delete_tokens(credential_store.as_ref());
     }
 
     // ========== Request Header Tests ==========

--- a/src-tauri/src/auth.rs
+++ b/src-tauri/src/auth.rs
@@ -777,17 +777,13 @@ pub async fn is_authenticated() -> Result<bool, String> {
     is_authenticated_with_store(&store).await
 }
 
+// Mock credential store for testing - accessible to all test modules
 #[cfg(test)]
-mod tests {
+pub mod mock {
     use super::*;
     use std::collections::HashMap;
     use std::sync::{Arc, Mutex};
 
-    // NOTE: These tests require access to the system keyring and are marked as #[ignore]
-    // by default. They can be run manually with: cargo test -- --ignored
-    // These tests may fail in headless CI environments without proper keyring setup.
-
-    // Mock credential store for testing
     pub struct MockCredentialStore {
         storage: Arc<Mutex<HashMap<String, String>>>,
     }
@@ -827,6 +823,19 @@ mod tests {
             Ok(())
         }
     }
+}
+
+// Re-export for backward compatibility with existing tests
+#[cfg(test)]
+pub use mock::MockCredentialStore;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // NOTE: These tests require access to the system keyring and are marked as #[ignore]
+    // by default. They can be run manually with: cargo test -- --ignored
+    // These tests may fail in headless CI environments without proper keyring setup.
 
     /// Helper to create test tokens with specific token sizes
     fn create_test_tokens(token_size: usize) -> AuthTokens {
@@ -1390,14 +1399,6 @@ mod tests {
     }
 
     #[tokio::test]
-    #[ignore] // Requires system keyring and HTTP mocking
-    async fn test_refresh_access_token_with_mock() {
-        // This test would require setting up a mockito server
-        // to mock the Keycloak token endpoint
-        // Skipping for now as it requires more complex setup
-    }
-
-    #[tokio::test]
     async fn test_is_authenticated_no_tokens() {
         cleanup_test_tokens();
 
@@ -1409,72 +1410,6 @@ mod tests {
             false,
             "Should not be authenticated without tokens"
         );
-
-        cleanup_test_tokens();
-    }
-
-    #[tokio::test]
-    #[ignore] // Requires system keyring
-    async fn test_is_authenticated_with_valid_token() {
-        cleanup_test_tokens();
-
-        // Store tokens with future expiration
-        let now = SystemTime::now()
-            .duration_since(UNIX_EPOCH)
-            .unwrap()
-            .as_secs() as i64;
-        let future_expiry = now + 3600; // Expires in 1 hour
-
-        let tokens = AuthTokens {
-            access_token: "valid_access".to_string(),
-            refresh_token: "valid_refresh".to_string(),
-            id_token: "valid_id".to_string(),
-            expires_at: future_expiry,
-            session_state: "session".to_string(),
-        };
-
-        let store_result = store_tokens_default(&tokens);
-        assert!(store_result.is_ok());
-
-        // Check authentication status
-        let result = is_authenticated().await;
-        assert!(result.is_ok());
-        assert_eq!(
-            result.unwrap(),
-            true,
-            "Should be authenticated with valid tokens"
-        );
-
-        cleanup_test_tokens();
-    }
-
-    #[tokio::test]
-    #[ignore] // Requires system keyring and HTTP mocking
-    async fn test_is_authenticated_with_expired_token() {
-        cleanup_test_tokens();
-
-        // Store tokens with past expiration (expired)
-        let now = SystemTime::now()
-            .duration_since(UNIX_EPOCH)
-            .unwrap()
-            .as_secs() as i64;
-        let past_expiry = now - 3600; // Expired 1 hour ago
-
-        let tokens = AuthTokens {
-            access_token: "expired_access".to_string(),
-            refresh_token: "valid_refresh".to_string(),
-            id_token: "expired_id".to_string(),
-            expires_at: past_expiry,
-            session_state: "session".to_string(),
-        };
-
-        let store_result = store_tokens_default(&tokens);
-        assert!(store_result.is_ok());
-
-        // Check authentication status (will attempt refresh, which will fail without mock)
-        let result = is_authenticated().await;
-        assert!(result.is_ok());
-        // Result depends on whether refresh succeeds (needs HTTP mock)
 
         cleanup_test_tokens();
     }
@@ -1504,37 +1439,5 @@ mod tests {
             past_expiry <= now + 60,
             "Expired token should trigger refresh"
         );
-    }
-
-    #[tokio::test]
-    #[ignore] // Requires HTTP mocking with mockito
-    async fn test_refresh_access_token_success() {
-        // This test requires setting up mockito to mock the Keycloak endpoint
-        // Example of what this would look like:
-        // let mut server = mockito::Server::new_async().await;
-        // let mock = server.mock("POST", "/auth/realms/edumoov/protocol/openid-connect/token")
-        //     .with_status(200)
-        //     .with_body(r#"{"access_token":"new_access","refresh_token":"new_refresh","id_token":"new_id","expires_in":3600,"session_state":"session"}"#)
-        //     .create();
-        //
-        // Then test refresh_access_token() pointing to mock server
-        // This is left as future work
-    }
-
-    #[tokio::test]
-    #[ignore] // Requires HTTP mocking with mockito
-    async fn test_refresh_access_token_network_error() {
-        // This test requires setting up mockito to simulate network failure
-        // Example: Mock server returns 500 or connection refused
-        // Verify that refresh_access_token() returns appropriate error
-        // This is left as future work
-    }
-
-    #[tokio::test]
-    #[ignore] // Requires HTTP mocking with mockito
-    async fn test_refresh_access_token_invalid_refresh_token() {
-        // This test requires setting up mockito to return 401 Unauthorized
-        // Verify that refresh_access_token() returns appropriate error
-        // This is left as future work
     }
 }


### PR DESCRIPTION
## Summary

This PR addresses issue #97 by cleaning up 15 ignored tests in the codebase. The work is divided into two main tasks:

1. **Delete 6 redundant tests in auth.rs** - These were empty placeholders or duplicates of better mock-based versions
2. **Update and un-ignore 9 tests in api.rs** - Convert these to use MockCredentialStore instead of KeyringCredentialStore

## Changes

### Task 1: Deleted Redundant Tests in auth.rs

Removed 6 tests that are no longer needed:
- `test_refresh_access_token_with_mock` (empty placeholder)
- `test_is_authenticated_with_valid_token` (replaced by `test_is_authenticated_with_store_valid_token`)
- `test_is_authenticated_with_expired_token` (replaced by `test_get_valid_access_token_with_store_expired_token`)
- `test_refresh_access_token_success` (empty placeholder)
- `test_refresh_access_token_network_error` (empty placeholder)
- `test_refresh_access_token_invalid_refresh_token` (empty placeholder)

### Task 2: Updated and Un-ignored Tests in api.rs

Updated 9 tests to use MockCredentialStore:
- `test_get_user_info_success`
- `test_get_user_info_unauthorized`
- `test_get_activities_success`
- `test_get_activities_empty`
- `test_get_activities_server_error`
- `test_get_signed_media_url_redirect`
- `test_get_signed_media_url_no_location_header`
- `test_get_signed_media_url_not_redirect`
- `test_fetch_all_activities_integration`

**For each test:**
- Removed `#[ignore]` attribute
- Replaced `Arc::new(crate::auth::KeyringCredentialStore::new())` with `Arc::new(crate::auth::MockCredentialStore::new())`
- Replaced `auth::store_tokens_default(&tokens)` with `crate::auth::store_tokens(credential_store.as_ref(), &tokens)`
- Replaced `auth::delete_tokens_default()` with `crate::auth::delete_tokens(credential_store.as_ref())`
- Removed keyring failure checks

### Infrastructure Changes

To support the migration to MockCredentialStore in api.rs tests:
- Moved `MockCredentialStore` from the `tests` module to a new public `mock` module in auth.rs
- Added public re-export `pub use mock::MockCredentialStore` for backward compatibility
- Tests now use the public API functions with credential_store parameters

## Test Results

✅ All 134 tests pass
✅ 0 tests ignored (previously 15)
✅ All acceptance criteria met

## Related Issues

Closes #97