### PR TITLE
feat: Add mock tests for window operations (#106)

### DIFF
--- a/src/__tests__/window-operations.test.ts
+++ b/src/__tests__/window-operations.test.ts
@@ -1,0 +1,789 @@
+/**
+ * Window Operations Test Suite
+ *
+ * This file demonstrates how to write unit tests for Tauri window operations
+ * using mockWindows() from @tauri-apps/api/mocks.
+ *
+ * Key concepts:
+ * - mockWindows() allows simulating multiple window instances
+ * - First parameter identifies the "current" window
+ * - Additional parameters represent other windows in the application
+ * - mockIPC() is used in combination to simulate window properties
+ * - Tests verify window labels, multi-window scenarios, and window APIs
+ *
+ * Note: mockWindows() only fakes the existence of windows, not their properties.
+ * To test window properties, combine mockWindows() with mockIPC().
+ *
+ * Important: getAllWebviewWindows() internally calls invoke('plugin:window|get_all_windows'),
+ * so we need to mock this IPC call when testing getAll functionality.
+ */
+
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { mockWindows, mockIPC, clearMocks } from '@tauri-apps/api/mocks';
+import { getCurrentWebviewWindow, getAllWebviewWindows } from '@tauri-apps/api/webviewWindow';
+
+/**
+ * Single Window Tests
+ * Tests for basic window detection in single-window scenarios
+ */
+describe('Window Operations - Single Window', () => {
+  beforeEach(() => {
+    // Clear all mocks before each test to ensure test isolation
+    clearMocks();
+  });
+
+  it('should get current window with correct label', () => {
+    // Mock a single window with label 'main'
+    mockWindows('main');
+
+    const currentWindow = getCurrentWebviewWindow();
+
+    // Verify the current window has the expected label
+    expect(currentWindow).toBeDefined();
+    expect(currentWindow.label).toBe('main');
+  });
+
+  it('should return only one window in getAll for single window scenario', async () => {
+    mockWindows('main');
+
+    // Mock the IPC call that getAllWebviewWindows uses internally
+    mockIPC((cmd) => {
+      if (cmd === 'plugin:window|get_all_windows') {
+        return ['main'];
+      }
+    });
+
+    const allWindows = await getAllWebviewWindows();
+
+    // Verify only one window exists
+    expect(allWindows).toHaveLength(1);
+    expect(allWindows[0].label).toBe('main');
+  });
+
+  it('should handle window with custom label', async () => {
+    // Test with a different window label
+    mockWindows('settings');
+
+    mockIPC((cmd) => {
+      if (cmd === 'plugin:window|get_all_windows') {
+        return ['settings'];
+      }
+    });
+
+    const currentWindow = getCurrentWebviewWindow();
+    const allWindows = await getAllWebviewWindows();
+
+    expect(currentWindow.label).toBe('settings');
+    expect(allWindows).toHaveLength(1);
+    expect(allWindows[0].label).toBe('settings');
+  });
+});
+
+/**
+ * Multi-Window Tests
+ * Tests for window detection in applications with multiple windows
+ */
+describe('Window Operations - Multi-Window', () => {
+  beforeEach(() => {
+    clearMocks();
+  });
+
+  it('should identify correct current window in multi-window scenario', () => {
+    // First parameter is the "current" window
+    mockWindows('main', 'settings', 'about');
+
+    const currentWindow = getCurrentWebviewWindow();
+
+    // Verify the first window is identified as current
+    expect(currentWindow.label).toBe('main');
+  });
+
+  it('should list all windows in multi-window scenario', async () => {
+    mockWindows('main', 'settings', 'about');
+
+    mockIPC((cmd) => {
+      if (cmd === 'plugin:window|get_all_windows') {
+        return ['main', 'settings', 'about'];
+      }
+    });
+
+    const allWindows = await getAllWebviewWindows();
+
+    // Verify all three windows are present
+    expect(allWindows).toHaveLength(3);
+    expect(allWindows.map((w) => w.label)).toEqual(['main', 'settings', 'about']);
+  });
+
+  it('should handle two-window scenario with splash screen', async () => {
+    // Common pattern: main window and splash screen
+    mockWindows('splash', 'main');
+
+    mockIPC((cmd) => {
+      if (cmd === 'plugin:window|get_all_windows') {
+        return ['splash', 'main'];
+      }
+    });
+
+    const currentWindow = getCurrentWebviewWindow();
+    const allWindows = await getAllWebviewWindows();
+
+    expect(currentWindow.label).toBe('splash');
+    expect(allWindows).toHaveLength(2);
+    expect(allWindows.map((w) => w.label)).toContain('splash');
+    expect(allWindows.map((w) => w.label)).toContain('main');
+  });
+
+  it('should handle multiple utility windows', async () => {
+    mockWindows('main', 'preferences', 'help', 'logs', 'updater');
+
+    mockIPC((cmd) => {
+      if (cmd === 'plugin:window|get_all_windows') {
+        return ['main', 'preferences', 'help', 'logs', 'updater'];
+      }
+    });
+
+    const allWindows = await getAllWebviewWindows();
+
+    expect(allWindows).toHaveLength(5);
+    const labels = allWindows.map((w) => w.label);
+    expect(labels).toContain('main');
+    expect(labels).toContain('preferences');
+    expect(labels).toContain('help');
+    expect(labels).toContain('logs');
+    expect(labels).toContain('updater');
+  });
+
+  it('should maintain window order as specified in mockWindows', async () => {
+    mockWindows('window-1', 'window-2', 'window-3', 'window-4');
+
+    mockIPC((cmd) => {
+      if (cmd === 'plugin:window|get_all_windows') {
+        return ['window-1', 'window-2', 'window-3', 'window-4'];
+      }
+    });
+
+    const allWindows = await getAllWebviewWindows();
+    const labels = allWindows.map((w) => w.label);
+
+    expect(labels).toEqual(['window-1', 'window-2', 'window-3', 'window-4']);
+  });
+});
+
+/**
+ * Window Label Detection Tests
+ * Tests for identifying and working with specific window labels
+ */
+describe('Window Operations - Label Detection', () => {
+  beforeEach(() => {
+    clearMocks();
+  });
+
+  it('should find specific window by label', async () => {
+    mockWindows('main', 'settings', 'about');
+
+    mockIPC((cmd) => {
+      if (cmd === 'plugin:window|get_all_windows') {
+        return ['main', 'settings', 'about'];
+      }
+    });
+
+    const allWindows = await getAllWebviewWindows();
+    const settingsWindow = allWindows.find((w) => w.label === 'settings');
+
+    expect(settingsWindow).toBeDefined();
+    expect(settingsWindow?.label).toBe('settings');
+  });
+
+  it('should detect if window label exists in application', async () => {
+    mockWindows('main', 'preferences', 'help');
+
+    mockIPC((cmd) => {
+      if (cmd === 'plugin:window|get_all_windows') {
+        return ['main', 'preferences', 'help'];
+      }
+    });
+
+    const allWindows = await getAllWebviewWindows();
+    const labels = allWindows.map((w) => w.label);
+
+    // Verify specific window exists
+    expect(labels.includes('preferences')).toBe(true);
+
+    // Verify non-existent window
+    expect(labels.includes('nonexistent')).toBe(false);
+  });
+
+  it('should filter windows by label pattern', async () => {
+    mockWindows('main', 'auth-window', 'auth-callback', 'settings');
+
+    mockIPC((cmd) => {
+      if (cmd === 'plugin:window|get_all_windows') {
+        return ['main', 'auth-window', 'auth-callback', 'settings'];
+      }
+    });
+
+    const allWindows = await getAllWebviewWindows();
+    const authWindows = allWindows.filter((w) => w.label.startsWith('auth-'));
+
+    expect(authWindows).toHaveLength(2);
+    expect(authWindows.map((w) => w.label)).toEqual(['auth-window', 'auth-callback']);
+  });
+
+  it('should count windows of specific type', async () => {
+    mockWindows('main', 'modal-1', 'modal-2', 'modal-3', 'settings');
+
+    mockIPC((cmd) => {
+      if (cmd === 'plugin:window|get_all_windows') {
+        return ['main', 'modal-1', 'modal-2', 'modal-3', 'settings'];
+      }
+    });
+
+    const allWindows = await getAllWebviewWindows();
+    const modalCount = allWindows.filter((w) => w.label.startsWith('modal-')).length;
+
+    expect(modalCount).toBe(3);
+  });
+});
+
+/**
+ * Window Properties with mockIPC Tests
+ * Tests combining mockWindows() with mockIPC() to simulate window properties
+ *
+ * Note: mockWindows() only fakes window existence, not properties.
+ * Use mockIPC() to simulate window properties and behavior.
+ */
+describe('Window Operations - Properties with mockIPC', () => {
+  beforeEach(() => {
+    clearMocks();
+  });
+
+  it('should mock window title property', async () => {
+    mockWindows('main');
+
+    const mockFn = vi.fn();
+    mockIPC((cmd, args) => {
+      mockFn(cmd, args);
+      // Mock the window title command
+      if (cmd === 'plugin:window|title') {
+        return 'Educartable Sync';
+      }
+    });
+
+    const currentWindow = getCurrentWebviewWindow();
+    const title = await currentWindow.title();
+
+    expect(title).toBe('Educartable Sync');
+    expect(mockFn).toHaveBeenCalledWith('plugin:window|title', expect.any(Object));
+  });
+
+  it('should mock window visibility state', async () => {
+    mockWindows('main', 'hidden-window');
+
+    const mockFn = vi.fn();
+    mockIPC((cmd, args) => {
+      mockFn(cmd, args);
+      if (cmd === 'plugin:window|get_all_windows') {
+        return ['main', 'hidden-window'];
+      }
+      // Mock isVisible command based on window label
+      if (cmd === 'plugin:window|is_visible') {
+        const label = args.label || 'main';
+        return label === 'main';
+      }
+    });
+
+    const allWindows = await getAllWebviewWindows();
+    const mainWindow = allWindows.find((w) => w.label === 'main');
+    const hiddenWindow = allWindows.find((w) => w.label === 'hidden-window');
+
+    const mainVisible = await mainWindow?.isVisible();
+    const hiddenVisible = await hiddenWindow?.isVisible();
+
+    expect(mainVisible).toBe(true);
+    expect(hiddenVisible).toBe(false);
+  });
+
+  it('should mock window size', async () => {
+    mockWindows('main');
+
+    const mockFn = vi.fn();
+
+    mockIPC((cmd, args) => {
+      mockFn(cmd, args);
+      if (cmd === 'plugin:window|inner_size') {
+        // Return the expected format for Tauri window size
+        return { type: 'Physical', width: 1024, height: 768 };
+      }
+    });
+
+    const currentWindow = getCurrentWebviewWindow();
+    const size = await currentWindow.innerSize();
+
+    // Check the size properties
+    expect(size.width).toBe(1024);
+    expect(size.height).toBe(768);
+    expect(mockFn).toHaveBeenCalledWith('plugin:window|inner_size', expect.any(Object));
+  });
+
+  it('should mock window position', async () => {
+    mockWindows('main');
+
+    const mockFn = vi.fn();
+
+    mockIPC((cmd, args) => {
+      mockFn(cmd, args);
+      if (cmd === 'plugin:window|outer_position') {
+        // Return the expected format for Tauri window position
+        return { type: 'Physical', x: 100, y: 50 };
+      }
+    });
+
+    const currentWindow = getCurrentWebviewWindow();
+    const position = await currentWindow.outerPosition();
+
+    // Check the position properties
+    expect(position.x).toBe(100);
+    expect(position.y).toBe(50);
+    expect(mockFn).toHaveBeenCalledWith('plugin:window|outer_position', expect.any(Object));
+  });
+
+  it('should mock window focus state', async () => {
+    mockWindows('main', 'background-window');
+
+    const mockFn = vi.fn();
+    mockIPC((cmd, args) => {
+      mockFn(cmd, args);
+      if (cmd === 'plugin:window|get_all_windows') {
+        return ['main', 'background-window'];
+      }
+      if (cmd === 'plugin:window|is_focused') {
+        const label = args.label || 'main';
+        return label === 'main';
+      }
+    });
+
+    const allWindows = await getAllWebviewWindows();
+    const mainWindow = allWindows.find((w) => w.label === 'main');
+    const backgroundWindow = allWindows.find((w) => w.label === 'background-window');
+
+    const mainFocused = await mainWindow?.isFocused();
+    const backgroundFocused = await backgroundWindow?.isFocused();
+
+    expect(mainFocused).toBe(true);
+    expect(backgroundFocused).toBe(false);
+  });
+
+  it('should mock window fullscreen state', async () => {
+    mockWindows('main');
+
+    const mockFn = vi.fn();
+    mockIPC((cmd, args) => {
+      mockFn(cmd, args);
+      if (cmd === 'plugin:window|is_fullscreen') {
+        return false;
+      }
+    });
+
+    const currentWindow = getCurrentWebviewWindow();
+    const isFullscreen = await currentWindow.isFullscreen();
+
+    expect(isFullscreen).toBe(false);
+    expect(mockFn).toHaveBeenCalledWith('plugin:window|is_fullscreen', expect.any(Object));
+  });
+
+  it('should mock window minimize state', async () => {
+    mockWindows('main', 'minimized-window');
+
+    const mockFn = vi.fn();
+    mockIPC((cmd, args) => {
+      mockFn(cmd, args);
+      if (cmd === 'plugin:window|get_all_windows') {
+        return ['main', 'minimized-window'];
+      }
+      if (cmd === 'plugin:window|is_minimized') {
+        const label = args.label || 'main';
+        return label === 'minimized-window';
+      }
+    });
+
+    const allWindows = await getAllWebviewWindows();
+    const mainWindow = allWindows.find((w) => w.label === 'main');
+    const minimizedWindow = allWindows.find((w) => w.label === 'minimized-window');
+
+    const mainMinimized = await mainWindow?.isMinimized();
+    const otherMinimized = await minimizedWindow?.isMinimized();
+
+    expect(mainMinimized).toBe(false);
+    expect(otherMinimized).toBe(true);
+  });
+});
+
+/**
+ * Window Actions with mockIPC Tests
+ * Tests for window actions (show, hide, close, etc.)
+ */
+describe('Window Operations - Actions with mockIPC', () => {
+  beforeEach(() => {
+    clearMocks();
+  });
+
+  it('should mock window show action', async () => {
+    mockWindows('main');
+
+    const mockFn = vi.fn();
+    mockIPC((cmd, args) => {
+      mockFn(cmd, args);
+      if (cmd === 'plugin:window|show') {
+        return null; // show returns void
+      }
+    });
+
+    const currentWindow = getCurrentWebviewWindow();
+    await currentWindow.show();
+
+    expect(mockFn).toHaveBeenCalledWith('plugin:window|show', expect.any(Object));
+    expect(mockFn).toHaveBeenCalledTimes(1);
+  });
+
+  it('should mock window hide action', async () => {
+    mockWindows('main');
+
+    const mockFn = vi.fn();
+    mockIPC((cmd, args) => {
+      mockFn(cmd, args);
+      if (cmd === 'plugin:window|hide') {
+        return null; // hide returns void
+      }
+    });
+
+    const currentWindow = getCurrentWebviewWindow();
+    await currentWindow.hide();
+
+    expect(mockFn).toHaveBeenCalledWith('plugin:window|hide', expect.any(Object));
+    expect(mockFn).toHaveBeenCalledTimes(1);
+  });
+
+  it('should mock window close action', async () => {
+    mockWindows('main');
+
+    const mockFn = vi.fn();
+    mockIPC((cmd, args) => {
+      mockFn(cmd, args);
+      if (cmd === 'plugin:window|close') {
+        return null; // close returns void
+      }
+    });
+
+    const currentWindow = getCurrentWebviewWindow();
+    await currentWindow.close();
+
+    expect(mockFn).toHaveBeenCalledWith('plugin:window|close', expect.any(Object));
+    expect(mockFn).toHaveBeenCalledTimes(1);
+  });
+
+  it('should mock window focus action', async () => {
+    mockWindows('main', 'background');
+
+    const mockFn = vi.fn();
+    mockIPC((cmd, args) => {
+      mockFn(cmd, args);
+      if (cmd === 'plugin:window|get_all_windows') {
+        return ['main', 'background'];
+      }
+      if (cmd === 'plugin:window|set_focus') {
+        return null; // focus returns void
+      }
+    });
+
+    const allWindows = await getAllWebviewWindows();
+    const backgroundWindow = allWindows.find((w) => w.label === 'background');
+    await backgroundWindow?.setFocus();
+
+    expect(mockFn).toHaveBeenCalledWith('plugin:window|set_focus', expect.any(Object));
+    expect(mockFn).toHaveBeenCalledTimes(2); // 1 for get_all_windows, 1 for set_focus
+  });
+
+  it('should mock window minimize action', async () => {
+    mockWindows('main');
+
+    const mockFn = vi.fn();
+    mockIPC((cmd, args) => {
+      mockFn(cmd, args);
+      if (cmd === 'plugin:window|minimize') {
+        return null; // minimize returns void
+      }
+    });
+
+    const currentWindow = getCurrentWebviewWindow();
+    await currentWindow.minimize();
+
+    expect(mockFn).toHaveBeenCalledWith('plugin:window|minimize', expect.any(Object));
+    expect(mockFn).toHaveBeenCalledTimes(1);
+  });
+
+  it('should mock window maximize action', async () => {
+    mockWindows('main');
+
+    const mockFn = vi.fn();
+    mockIPC((cmd, args) => {
+      mockFn(cmd, args);
+      if (cmd === 'plugin:window|maximize') {
+        return null; // maximize returns void
+      }
+    });
+
+    const currentWindow = getCurrentWebviewWindow();
+    await currentWindow.maximize();
+
+    expect(mockFn).toHaveBeenCalledWith('plugin:window|maximize', expect.any(Object));
+    expect(mockFn).toHaveBeenCalledTimes(1);
+  });
+
+  it('should mock window resize action', async () => {
+    mockWindows('main');
+
+    const mockFn = vi.fn();
+
+    mockIPC((cmd, args) => {
+      mockFn(cmd, args);
+      if (cmd === 'plugin:window|set_size') {
+        return null; // resize returns void
+      }
+    });
+
+    const currentWindow = getCurrentWebviewWindow();
+    // Use the LogicalSize or PhysicalSize format
+    await currentWindow.setSize({ type: 'Logical', width: 800, height: 600 });
+
+    expect(mockFn).toHaveBeenCalledWith('plugin:window|set_size', expect.any(Object));
+    expect(mockFn).toHaveBeenCalledTimes(1);
+  });
+});
+
+/**
+ * Real-World Scenarios
+ * Tests simulating actual application use cases
+ */
+describe('Window Operations - Real-World Scenarios', () => {
+  beforeEach(() => {
+    clearMocks();
+  });
+
+  it('should simulate authentication window flow', async () => {
+    // Simulate app with main window and auth window
+    mockWindows('main', 'auth-window');
+
+    const mockFn = vi.fn();
+    mockIPC((cmd, args) => {
+      mockFn(cmd, args);
+      if (cmd === 'plugin:window|get_all_windows') {
+        return ['main', 'auth-window'];
+      }
+      if (cmd === 'plugin:window|show') {
+        return null;
+      }
+      if (cmd === 'plugin:window|close') {
+        return null;
+      }
+    });
+
+    const allWindows = await getAllWebviewWindows();
+    const authWindow = allWindows.find((w) => w.label === 'auth-window');
+
+    // Simulate showing auth window for login
+    await authWindow?.show();
+    expect(mockFn).toHaveBeenCalledWith('plugin:window|show', expect.any(Object));
+
+    // After authentication, close auth window
+    await authWindow?.close();
+    expect(mockFn).toHaveBeenCalledWith('plugin:window|close', expect.any(Object));
+    expect(mockFn).toHaveBeenCalledTimes(3); // 1 for get_all, 1 for show, 1 for close
+  });
+
+  it('should simulate splash screen to main window transition', async () => {
+    mockWindows('splash', 'main');
+
+    const mockFn = vi.fn();
+    mockIPC((cmd, args) => {
+      mockFn(cmd, args);
+      if (cmd === 'plugin:window|get_all_windows') {
+        return ['splash', 'main'];
+      }
+      if (cmd === 'plugin:window|hide') {
+        return null;
+      }
+      if (cmd === 'plugin:window|show') {
+        return null;
+      }
+    });
+
+    const allWindows = await getAllWebviewWindows();
+    const splashWindow = allWindows.find((w) => w.label === 'splash');
+    const mainWindow = allWindows.find((w) => w.label === 'main');
+
+    // After loading, hide splash and show main
+    await splashWindow?.hide();
+    await mainWindow?.show();
+
+    expect(mockFn).toHaveBeenNthCalledWith(2, 'plugin:window|hide', expect.any(Object));
+    expect(mockFn).toHaveBeenNthCalledWith(3, 'plugin:window|show', expect.any(Object));
+    expect(mockFn).toHaveBeenCalledTimes(3); // 1 for get_all, 1 for hide, 1 for show
+  });
+
+  it('should simulate modal dialog workflow', async () => {
+    mockWindows('main', 'settings-modal');
+
+    const mockFn = vi.fn();
+    mockIPC((cmd, args) => {
+      mockFn(cmd, args);
+      if (cmd === 'plugin:window|get_all_windows') {
+        return ['main', 'settings-modal'];
+      }
+      if (cmd === 'plugin:window|show') {
+        return null;
+      }
+      if (cmd === 'plugin:window|set_focus') {
+        return null;
+      }
+      if (cmd === 'plugin:window|close') {
+        return null;
+      }
+    });
+
+    const allWindows = await getAllWebviewWindows();
+    const modal = allWindows.find((w) => w.label === 'settings-modal');
+
+    // Show and focus modal
+    await modal?.show();
+    await modal?.setFocus();
+
+    // User closes modal
+    await modal?.close();
+
+    expect(mockFn).toHaveBeenCalledTimes(4); // 1 for get_all, 1 for show, 1 for focus, 1 for close
+    expect(mockFn).toHaveBeenNthCalledWith(2, 'plugin:window|show', expect.any(Object));
+    expect(mockFn).toHaveBeenNthCalledWith(3, 'plugin:window|set_focus', expect.any(Object));
+    expect(mockFn).toHaveBeenNthCalledWith(4, 'plugin:window|close', expect.any(Object));
+  });
+
+  it('should simulate multi-window state management', async () => {
+    mockWindows('main', 'window-1', 'window-2', 'window-3');
+
+    const mockFn = vi.fn();
+    mockIPC((cmd, args) => {
+      mockFn(cmd, args);
+      if (cmd === 'plugin:window|get_all_windows') {
+        return ['main', 'window-1', 'window-2', 'window-3'];
+      }
+      if (cmd === 'plugin:window|is_visible') {
+        // Simulate some windows visible, some hidden
+        const label = args.label || 'main';
+        return label === 'main' || label === 'window-1';
+      }
+    });
+
+    const allWindows = await getAllWebviewWindows();
+
+    // Check which windows are visible
+    const visibilityStates = await Promise.all(
+      allWindows.map(async (w) => ({
+        label: w.label,
+        visible: await w.isVisible()
+      }))
+    );
+
+    const visibleWindows = visibilityStates.filter((s) => s.visible);
+    const hiddenWindows = visibilityStates.filter((s) => !s.visible);
+
+    expect(visibleWindows).toHaveLength(2);
+    expect(hiddenWindows).toHaveLength(2);
+    expect(visibleWindows.map((w) => w.label)).toEqual(['main', 'window-1']);
+    expect(hiddenWindows.map((w) => w.label)).toEqual(['window-2', 'window-3']);
+  });
+});
+
+/**
+ * Edge Cases and Error Handling
+ * Tests for unusual scenarios and error conditions
+ */
+describe('Window Operations - Edge Cases', () => {
+  beforeEach(() => {
+    clearMocks();
+  });
+
+  it('should handle empty window label', () => {
+    mockWindows('');
+
+    const currentWindow = getCurrentWebviewWindow();
+    expect(currentWindow.label).toBe('');
+  });
+
+  it('should handle windows with special characters in labels', async () => {
+    mockWindows('main-window-2024', 'window_with_underscores', 'window.with.dots');
+
+    mockIPC((cmd) => {
+      if (cmd === 'plugin:window|get_all_windows') {
+        return ['main-window-2024', 'window_with_underscores', 'window.with.dots'];
+      }
+    });
+
+    const allWindows = await getAllWebviewWindows();
+    expect(allWindows).toHaveLength(3);
+    expect(allWindows[0].label).toBe('main-window-2024');
+    expect(allWindows[1].label).toBe('window_with_underscores');
+    expect(allWindows[2].label).toBe('window.with.dots');
+  });
+
+  it('should handle window not found scenario', async () => {
+    mockWindows('main', 'settings');
+
+    mockIPC((cmd) => {
+      if (cmd === 'plugin:window|get_all_windows') {
+        return ['main', 'settings'];
+      }
+    });
+
+    const allWindows = await getAllWebviewWindows();
+    const nonExistentWindow = allWindows.find((w) => w.label === 'nonexistent');
+
+    expect(nonExistentWindow).toBeUndefined();
+  });
+
+  it('should handle window action errors', async () => {
+    mockWindows('main');
+
+    const mockFn = vi.fn();
+    mockIPC((cmd, args) => {
+      mockFn(cmd, args);
+      if (cmd === 'plugin:window|close') {
+        throw new Error('Window close failed');
+      }
+    });
+
+    const currentWindow = getCurrentWebviewWindow();
+
+    await expect(currentWindow.close()).rejects.toThrow('Window close failed');
+    expect(mockFn).toHaveBeenCalledWith('plugin:window|close', expect.any(Object));
+  });
+
+  it('should handle multiple rapid window queries', async () => {
+    mockWindows('main', 'window-1', 'window-2');
+
+    mockIPC((cmd) => {
+      if (cmd === 'plugin:window|get_all_windows') {
+        return ['main', 'window-1', 'window-2'];
+      }
+    });
+
+    // Simulate rapid queries
+    const calls = await Promise.all(
+      Array.from({ length: 10 }, () => getAllWebviewWindows())
+    );
+
+    // All calls should return consistent results
+    calls.forEach((windows) => {
+      expect(windows).toHaveLength(3);
+      expect(windows.map((w) => w.label)).toEqual(['main', 'window-1', 'window-2']);
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Implements comprehensive mock tests for Tauri window operations
- Tests cover single-window, multi-window, and window label detection scenarios
- Adds examples for `getCurrent()`, `getAll()`, and window properties/actions
- 35 new tests, all passing

## Changes
- Created `src/__tests__/window-operations.test.ts` with 7 test suites:
  1. Single window operations (3 tests)
  2. Multi-window scenarios (5 tests)
  3. Window label detection (4 tests)
  4. Window properties with mockIPC (7 tests)
  5. Window actions with mockIPC (7 tests)
  6. Real-world scenarios (4 tests)
  7. Edge cases and error handling (5 tests)

## Test Results
✅ All 62 tests pass (35 new + 27 existing)

## Related Issues
- Closes #106
- Part of #103

## Test plan
- [x] Tests pass locally (`npm test`)
- [x] All 35 new window operation tests pass
- [x] Existing tests still pass (no regressions)
- [x] Ready for CI