### PR TITLE
feat: allow users to select which activities to sync

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -96,6 +96,7 @@ pub fn run() {
             config::load_config,
             config::save_config,
             config::select_sync_directory,
+            sync::fetch_activities,
             sync::start_sync,
             open_logs_directory,
             updater::check_for_updates,

--- a/src-tauri/src/models.rs
+++ b/src-tauri/src/models.rs
@@ -94,6 +94,19 @@ pub struct AppConfig {
     pub sync_path: PathBuf,
 }
 
+// Issue #131: Sync state for tracking previously synced activities
+#[derive(Debug, Serialize, Deserialize, Default, Clone)]
+pub struct SyncState {
+    pub synced_activity_ids: Vec<String>,
+}
+
+// Issue #131: Response type for fetch_activities command
+#[derive(Debug, Serialize, Clone)]
+pub struct FetchActivitiesResponse {
+    pub activities: Vec<Activity>,
+    pub previously_synced_ids: Vec<String>,
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -424,5 +437,88 @@ mod tests {
 
         let user_info: UserInfo = serde_json::from_str(json).unwrap();
         assert_eq!(user_info.id, 999999999999);
+    }
+
+    // ========== Tests for SyncState (Issue #131) ==========
+
+    #[test]
+    fn test_sync_state_default() {
+        let state = SyncState::default();
+        assert_eq!(state.synced_activity_ids.len(), 0);
+    }
+
+    #[test]
+    fn test_sync_state_serialization() {
+        let state = SyncState {
+            synced_activity_ids: vec!["act1".to_string(), "act2".to_string(), "act3".to_string()],
+        };
+
+        let json = serde_json::to_string(&state).unwrap();
+        assert!(json.contains("synced_activity_ids"));
+        assert!(json.contains("act1"));
+        assert!(json.contains("act2"));
+        assert!(json.contains("act3"));
+    }
+
+    #[test]
+    fn test_sync_state_deserialization() {
+        let json = r#"{"synced_activity_ids":["activity_123","activity_456"]}"#;
+        let state: SyncState = serde_json::from_str(json).unwrap();
+        assert_eq!(state.synced_activity_ids.len(), 2);
+        assert_eq!(state.synced_activity_ids[0], "activity_123");
+        assert_eq!(state.synced_activity_ids[1], "activity_456");
+    }
+
+    #[test]
+    fn test_sync_state_roundtrip() {
+        let state = SyncState {
+            synced_activity_ids: vec!["id1".to_string(), "id2".to_string()],
+        };
+
+        let json = serde_json::to_string(&state).unwrap();
+        let deserialized: SyncState = serde_json::from_str(&json).unwrap();
+        assert_eq!(state.synced_activity_ids, deserialized.synced_activity_ids);
+    }
+
+    #[test]
+    fn test_sync_state_empty() {
+        let json = r#"{"synced_activity_ids":[]}"#;
+        let state: SyncState = serde_json::from_str(json).unwrap();
+        assert_eq!(state.synced_activity_ids.len(), 0);
+    }
+
+    // ========== Tests for FetchActivitiesResponse (Issue #131) ==========
+
+    #[test]
+    fn test_fetch_activities_response_serialization() {
+        let response = FetchActivitiesResponse {
+            activities: vec![Activity {
+                id: "act123".to_string(),
+                title: "Test Activity".to_string(),
+                body: "Content".to_string(),
+                date: "2024-01-01T12:00:00Z".to_string(),
+                medias: vec![],
+                pupils: vec![1],
+            }],
+            previously_synced_ids: vec!["old_act1".to_string(), "old_act2".to_string()],
+        };
+
+        let json = serde_json::to_string(&response).unwrap();
+        assert!(json.contains("activities"));
+        assert!(json.contains("previously_synced_ids"));
+        assert!(json.contains("act123"));
+        assert!(json.contains("old_act1"));
+    }
+
+    #[test]
+    fn test_fetch_activities_response_empty() {
+        let response = FetchActivitiesResponse {
+            activities: vec![],
+            previously_synced_ids: vec![],
+        };
+
+        let json = serde_json::to_string(&response).unwrap();
+        assert!(json.contains("\"activities\":[]"));
+        assert!(json.contains("\"previously_synced_ids\":[]"));
     }
 }

--- a/src-tauri/src/sync.rs
+++ b/src-tauri/src/sync.rs
@@ -1,10 +1,10 @@
 // Sync engine for downloading media
 
 use crate::api::EducartableClient;
-use crate::models::{Activity, Media, SyncProgress, SyncStats};
+use crate::models::{Activity, FetchActivitiesResponse, Media, SyncProgress, SyncState, SyncStats};
 use reqwest::Client;
 use std::path::{Path, PathBuf};
-use tauri::{AppHandle, Emitter};
+use tauri::{AppHandle, Emitter, Manager};
 use tokio::fs;
 use tokio::fs::File;
 use tokio::io::AsyncWriteExt;
@@ -120,6 +120,84 @@ fn format_article_markdown(activity: &Activity) -> String {
         "# {}\n\nPublié le : {}\n\n{}",
         activity.title, date, activity.body
     )
+}
+
+// Issue #131: Sync state persistence functions
+
+/// Get the path to the sync state file
+fn get_sync_state_path(app_handle: &AppHandle) -> Result<PathBuf, String> {
+    log::debug!("Getting sync state file path");
+
+    let app_data_dir = app_handle.path().app_data_dir().map_err(|e| {
+        log::error!("Failed to get app data directory: {e}");
+        "Cannot access application data directory. Please check permissions.".to_string()
+    })?;
+
+    // Create directory if it doesn't exist
+    std::fs::create_dir_all(&app_data_dir).map_err(|e| {
+        log::error!("Failed to create app data directory: {e}");
+        "Cannot create application data directory. Please check disk space and permissions."
+            .to_string()
+    })?;
+
+    let state_path = app_data_dir.join("sync_state.json");
+    log::debug!("Sync state file path: {}", state_path.display());
+    Ok(state_path)
+}
+
+/// Load sync state from disk
+fn load_sync_state(app_handle: &AppHandle) -> Result<SyncState, String> {
+    log::info!("Loading sync state");
+    let state_path = get_sync_state_path(app_handle)?;
+
+    // If state file doesn't exist, return default state
+    if !state_path.exists() {
+        log::info!("Sync state file does not exist, returning default state");
+        return Ok(SyncState::default());
+    }
+
+    // Read and parse state file
+    log::debug!("Reading sync state from {}", state_path.display());
+    let state_json = std::fs::read_to_string(&state_path).map_err(|e| {
+        log::error!("Failed to read sync state file: {e}");
+        "Cannot read sync state file. Please check permissions.".to_string()
+    })?;
+
+    let state: SyncState = serde_json::from_str(&state_json).map_err(|e| {
+        log::error!("Failed to parse sync state file: {e}");
+        "Sync state file is corrupted. Starting fresh.".to_string()
+    })?;
+
+    log::info!(
+        "Sync state loaded successfully with {} previously synced activities",
+        state.synced_activity_ids.len()
+    );
+    Ok(state)
+}
+
+/// Save sync state to disk
+fn save_sync_state(app_handle: &AppHandle, state: &SyncState) -> Result<(), String> {
+    log::info!("Saving sync state");
+    let state_path = get_sync_state_path(app_handle)?;
+
+    // Serialize state to JSON
+    let state_json = serde_json::to_string_pretty(state).map_err(|e| {
+        log::error!("Failed to serialize sync state: {e}");
+        "Cannot prepare sync state for saving. Please try again.".to_string()
+    })?;
+
+    // Write to file
+    log::debug!("Writing sync state to {}", state_path.display());
+    std::fs::write(&state_path, state_json).map_err(|e| {
+        log::error!("Failed to write sync state file: {e}");
+        "Cannot save sync state. Please check disk space and permissions.".to_string()
+    })?;
+
+    log::info!(
+        "Sync state saved successfully with {} synced activities",
+        state.synced_activity_ids.len()
+    );
+    Ok(())
 }
 
 // Issue #27: Duplicate detection
@@ -268,7 +346,14 @@ impl<H: crate::api::HttpClient> SyncEngine<H> {
         let _ = self.app_handle.emit("sync-progress", &progress);
     }
 
-    pub async fn sync_all(&self) -> Result<SyncStats, Box<dyn std::error::Error + Send + Sync>> {
+    /// Sync all activities or a filtered subset
+    ///
+    /// # Arguments
+    /// * `selected_activity_ids` - Optional list of activity IDs to sync. If None, syncs all activities.
+    pub async fn sync_all(
+        &self,
+        selected_activity_ids: Option<Vec<String>>,
+    ) -> Result<SyncStats, Box<dyn std::error::Error + Send + Sync>> {
         log::info!("Starting sync operation");
         let mut stats = SyncStats::default();
 
@@ -285,7 +370,7 @@ impl<H: crate::api::HttpClient> SyncEngine<H> {
         // Fetch all activities
         self.emit_progress(0, 0, "Fetching activities...".to_string());
         log::info!("Fetching all activities");
-        let activities = self
+        let all_activities = self
             .api_client
             .fetch_all_activities(parent_id)
             .await
@@ -293,6 +378,18 @@ impl<H: crate::api::HttpClient> SyncEngine<H> {
                 log::error!("Failed to fetch activities: {e}");
                 "Cannot load activities from Educartable. Please check your connection.".to_string()
             })?;
+
+        // Filter activities if selected_activity_ids is provided
+        let activities: Vec<Activity> = if let Some(ids) = &selected_activity_ids {
+            log::info!("Filtering to {} selected activities", ids.len());
+            all_activities
+                .into_iter()
+                .filter(|a| ids.contains(&a.id))
+                .collect()
+        } else {
+            log::info!("Syncing all activities (no filter)");
+            all_activities
+        };
 
         #[allow(clippy::cast_possible_truncation)]
         {
@@ -397,6 +494,72 @@ impl<H: crate::api::HttpClient> SyncEngine<H> {
     }
 }
 
+/// Fetches activities from Educartable without syncing.
+///
+/// Returns the list of activities along with previously synced activity IDs.
+/// This allows the frontend to display a selection dialog for the user.
+///
+/// # Arguments
+/// * `app_handle` - Tauri application handle for accessing sync state
+///
+/// # Returns
+/// - `Ok(FetchActivitiesResponse)` - Activities and sync state
+/// - `Err(String)` - Failed to fetch activities
+///
+/// # Errors
+/// - User not authenticated
+/// - Network errors fetching activities
+// Issue #131: Tauri command for fetching activities before sync
+#[tauri::command]
+pub async fn fetch_activities(app_handle: AppHandle) -> Result<FetchActivitiesResponse, String> {
+    log::info!("Fetch activities command invoked");
+
+    // Verify authentication
+    log::debug!("Verifying authentication");
+    crate::auth::load_tokens_default().map_err(|e| {
+        log::error!("Not authenticated: {e}");
+        e
+    })?;
+
+    // Load sync state
+    let sync_state = load_sync_state(&app_handle).unwrap_or_else(|e| {
+        log::warn!("Failed to load sync state, using default: {e}");
+        SyncState::default()
+    });
+
+    // Create API client
+    let api_client = EducartableClient::new_no_redirect()
+        .map_err(|e| format!("Failed to create API client: {e}"))?;
+
+    // Get parent ID
+    log::info!("Fetching parent ID");
+    let parent_id = api_client.get_parent_id().await.map_err(|e| {
+        log::error!("Failed to get user info: {e}");
+        "Cannot access your account information. Please check your connection.".to_string()
+    })?;
+
+    // Fetch all activities
+    log::info!("Fetching all activities");
+    let activities = api_client
+        .fetch_all_activities(parent_id)
+        .await
+        .map_err(|e| {
+            log::error!("Failed to fetch activities: {e}");
+            "Cannot load activities from Educartable. Please check your connection.".to_string()
+        })?;
+
+    log::info!(
+        "Fetched {} activities, {} previously synced",
+        activities.len(),
+        sync_state.synced_activity_ids.len()
+    );
+
+    Ok(FetchActivitiesResponse {
+        activities,
+        previously_synced_ids: sync_state.synced_activity_ids,
+    })
+}
+
 /// Starts synchronization of media files from Educartable.
 ///
 /// Fetches all activities for the authenticated user, then downloads
@@ -407,6 +570,7 @@ impl<H: crate::api::HttpClient> SyncEngine<H> {
 /// # Arguments
 /// * `app_handle` - Tauri application handle for emitting progress events
 /// * `config` - Application configuration containing sync directory path
+/// * `selected_activity_ids` - Optional list of activity IDs to sync. If None, syncs all.
 ///
 /// # Returns
 /// - `Ok(SyncStats)` - Sync completed with download statistics
@@ -421,12 +585,20 @@ impl<H: crate::api::HttpClient> SyncEngine<H> {
 /// - Network errors fetching activities or media
 /// - File system errors creating directories or downloading files
 // Issue #34: Tauri command for starting sync
+// Issue #131: Modified to accept optional selected activity IDs
 #[tauri::command]
 pub async fn start_sync(
     app_handle: AppHandle,
     config: crate::models::AppConfig,
+    selected_activity_ids: Option<Vec<String>>,
 ) -> Result<SyncStats, String> {
     log::info!("Sync command invoked");
+
+    if let Some(ref ids) = selected_activity_ids {
+        log::info!("Syncing {} selected activities", ids.len());
+    } else {
+        log::info!("Syncing all activities");
+    }
 
     // Verify authentication (this will also attempt token refresh if needed)
     log::debug!("Verifying authentication");
@@ -448,14 +620,37 @@ pub async fn start_sync(
         .map_err(|e| format!("Failed to create API client: {e}"))?;
 
     // Create sync engine
-    let sync_engine = SyncEngine::new(app_handle, api_client, config.sync_path);
+    let sync_engine = SyncEngine::new(app_handle.clone(), api_client, config.sync_path);
 
-    // Run synchronization
+    // Run synchronization with optional filtering
     log::info!("Starting synchronization");
-    let result = sync_engine.sync_all().await.map_err(|e| {
-        log::error!("Sync failed: {e}");
-        e.to_string()
-    });
+    let result = sync_engine
+        .sync_all(selected_activity_ids.clone())
+        .await
+        .map_err(|e| {
+            log::error!("Sync failed: {e}");
+            e.to_string()
+        });
+
+    // If sync succeeded and we have selected activity IDs, update sync state
+    if result.is_ok() {
+        if let Some(ids) = selected_activity_ids {
+            // Load existing sync state
+            let mut sync_state = load_sync_state(&app_handle).unwrap_or_default();
+
+            // Add newly synced IDs (avoiding duplicates)
+            for id in ids {
+                if !sync_state.synced_activity_ids.contains(&id) {
+                    sync_state.synced_activity_ids.push(id);
+                }
+            }
+
+            // Save updated sync state
+            if let Err(e) = save_sync_state(&app_handle, &sync_state) {
+                log::warn!("Failed to save sync state: {e}");
+            }
+        }
+    }
 
     match &result {
         Ok(stats) => log::info!("Sync completed successfully: {stats:?}"),

--- a/src/index.html
+++ b/src/index.html
@@ -61,7 +61,7 @@
         <h2>📥 Synchronisation</h2>
 
         <button id="sync-btn" disabled>
-          Synchroniser maintenant
+          Synchroniser
         </button>
 
         <div id="sync-progress-container">
@@ -74,6 +74,31 @@
       </section>
     </article>
   </main>
+
+  <!-- Issue #131: Activity Selection Dialog -->
+  <dialog id="activity-selection-dialog">
+    <article class="activity-dialog-article">
+      <header>
+        <button id="close-dialog-btn" aria-label="Fermer" rel="prev"></button>
+        <h3>Selectionner les activites a synchroniser</h3>
+      </header>
+      <div class="activity-dialog-controls">
+        <div class="selection-controls">
+          <button id="select-all-btn" class="secondary btn-compact">Tout selectionner</button>
+          <button id="deselect-all-btn" class="secondary btn-compact">Tout deselectionner</button>
+        </div>
+        <span id="selection-count" class="selection-count">0 activite(s) selectionnee(s)</span>
+      </div>
+      <div id="activity-list-container" class="activity-list-container">
+        <!-- Dynamic activity checkboxes will be inserted here -->
+        <p id="loading-activities" class="loading-text">Chargement des activites...</p>
+      </div>
+      <footer>
+        <button id="cancel-selection-btn" class="secondary">Annuler</button>
+        <button id="confirm-sync-btn">Synchroniser la selection</button>
+      </footer>
+    </article>
+  </dialog>
 
   <script src="main.js" type="module"></script>
 </body>

--- a/src/main.js
+++ b/src/main.js
@@ -18,6 +18,8 @@ import { checkForUpdatesSilently, handleUpdateButtonClick } from './updater.js';
 // Application state
 let isAuthenticated = false;
 let config = null;
+let activitiesData = null; // Cached activities and sync state
+let selectedActivityIds = new Set(); // Currently selected activity IDs
 
 /**
  * Initialize the application when DOM is ready
@@ -57,8 +59,23 @@ function setupEventListeners() {
     document.getElementById('open-logs-btn').addEventListener('click', handleOpenLogs);
     document.getElementById('check-updates-btn').addEventListener('click', handleUpdateButtonClick);
 
-    // Sync button
-    document.getElementById('sync-btn').addEventListener('click', handleSync);
+    // Sync button - now opens activity selection dialog
+    document.getElementById('sync-btn').addEventListener('click', handleSyncButtonClick);
+
+    // Activity selection dialog buttons
+    document.getElementById('close-dialog-btn').addEventListener('click', closeActivityDialog);
+    document.getElementById('cancel-selection-btn').addEventListener('click', closeActivityDialog);
+    document.getElementById('confirm-sync-btn').addEventListener('click', handleConfirmSync);
+    document.getElementById('select-all-btn').addEventListener('click', handleSelectAll);
+    document.getElementById('deselect-all-btn').addEventListener('click', handleDeselectAll);
+
+    // Close dialog when clicking outside
+    const dialog = document.getElementById('activity-selection-dialog');
+    dialog.addEventListener('click', (e) => {
+        if (e.target === dialog) {
+            closeActivityDialog();
+        }
+    });
 }
 
 /**
@@ -358,19 +375,238 @@ function updateProgress(progress) {
 
 /**
  * Handle sync button click
- * Triggers synchronization with the backend
+ * Opens activity selection dialog instead of syncing directly
  */
-async function handleSync() {
-    console.log('Sync initiated...');
+async function handleSyncButtonClick() {
+    console.log('Sync button clicked, opening activity selection...');
 
     const syncBtn = document.getElementById('sync-btn');
 
     // Validate configuration
     if (!config.sync_path) {
-        const parsed = parseError('Dossier de synchronisation non configuré');
+        const parsed = parseError('Dossier de synchronisation non configure');
         showError(parsed.title, parsed.message, parsed.action);
         return;
     }
+
+    // Disable button and show loading state
+    syncBtn.disabled = true;
+    syncBtn.setAttribute('aria-busy', 'true');
+    const originalText = syncBtn.textContent;
+    syncBtn.textContent = 'Chargement...';
+
+    try {
+        // Fetch activities from backend
+        console.log('Fetching activities...');
+        activitiesData = await invoke('fetch_activities');
+        console.log('Fetched activities:', activitiesData);
+
+        // Open the activity selection dialog
+        openActivityDialog();
+    } catch (error) {
+        console.error('Failed to fetch activities:', error);
+        handleError(error, 'fetch activities');
+    } finally {
+        // Re-enable button
+        syncBtn.disabled = !isAuthenticated;
+        syncBtn.removeAttribute('aria-busy');
+        syncBtn.textContent = originalText;
+    }
+}
+
+/**
+ * Open the activity selection dialog and populate with activities
+ */
+function openActivityDialog() {
+    const dialog = document.getElementById('activity-selection-dialog');
+    const container = document.getElementById('activity-list-container');
+    const loadingText = document.getElementById('loading-activities');
+
+    // Clear previous content
+    container.innerHTML = '';
+
+    if (!activitiesData || activitiesData.activities.length === 0) {
+        container.innerHTML = '<p class="no-activities">Aucune activite trouvee.</p>';
+        dialog.showModal();
+        return;
+    }
+
+    // Determine pre-selection based on sync state
+    const previouslySyncedIds = new Set(activitiesData.previously_synced_ids || []);
+    const allActivityIds = new Set(activitiesData.activities.map(a => a.id));
+
+    // First sync (nothing synced yet): select all
+    // Subsequent syncs: select previously synced + new activities
+    if (previouslySyncedIds.size === 0) {
+        // First sync: select all
+        selectedActivityIds = new Set(allActivityIds);
+    } else {
+        // Subsequent syncs: pre-select previously synced + new activities
+        selectedActivityIds = new Set();
+        for (const activity of activitiesData.activities) {
+            // Select if previously synced OR if it's new (not in previously synced)
+            if (previouslySyncedIds.has(activity.id)) {
+                selectedActivityIds.add(activity.id);
+            } else {
+                // This is a new activity, also select it by default
+                selectedActivityIds.add(activity.id);
+            }
+        }
+    }
+
+    // Render activity list
+    renderActivityList();
+
+    // Update selection count
+    updateSelectionCount();
+
+    // Show dialog
+    dialog.showModal();
+}
+
+/**
+ * Render the activity list with checkboxes
+ */
+function renderActivityList() {
+    const container = document.getElementById('activity-list-container');
+    container.innerHTML = '';
+
+    // Sort activities by date (newest first)
+    const sortedActivities = [...activitiesData.activities].sort((a, b) => {
+        return new Date(b.date) - new Date(a.date);
+    });
+
+    for (const activity of sortedActivities) {
+        const isSelected = selectedActivityIds.has(activity.id);
+        const isPreviouslySynced = activitiesData.previously_synced_ids?.includes(activity.id);
+
+        // Format date
+        const date = activity.date.split('T')[0] || 'Date inconnue';
+
+        // Count media
+        const mediaCount = activity.medias?.length || 0;
+        const mediaText = mediaCount === 0 ? 'Pas de medias' :
+                         mediaCount === 1 ? '1 media' : `${mediaCount} medias`;
+
+        const item = document.createElement('label');
+        item.className = `activity-item${isSelected ? ' selected' : ''}${isPreviouslySynced ? ' previously-synced' : ''}`;
+        item.innerHTML = `
+            <input type="checkbox"
+                   value="${activity.id}"
+                   ${isSelected ? 'checked' : ''}
+                   class="activity-checkbox">
+            <div class="activity-info">
+                <span class="activity-title">${escapeHtml(activity.title)}</span>
+                <span class="activity-meta">
+                    <span class="activity-date">${date}</span>
+                    <span class="activity-media-count">${mediaText}</span>
+                    ${isPreviouslySynced ? '<span class="synced-badge">Deja synchronise</span>' : '<span class="new-badge">Nouveau</span>'}
+                </span>
+            </div>
+        `;
+
+        // Add event listener for checkbox change
+        const checkbox = item.querySelector('input');
+        checkbox.addEventListener('change', (e) => {
+            if (e.target.checked) {
+                selectedActivityIds.add(activity.id);
+                item.classList.add('selected');
+            } else {
+                selectedActivityIds.delete(activity.id);
+                item.classList.remove('selected');
+            }
+            updateSelectionCount();
+        });
+
+        container.appendChild(item);
+    }
+}
+
+/**
+ * Update the selection count display
+ */
+function updateSelectionCount() {
+    const count = selectedActivityIds.size;
+    const countElement = document.getElementById('selection-count');
+    countElement.textContent = `${count} activite(s) selectionnee(s)`;
+
+    // Disable confirm button if nothing selected
+    const confirmBtn = document.getElementById('confirm-sync-btn');
+    confirmBtn.disabled = count === 0;
+}
+
+/**
+ * Handle select all button click
+ */
+function handleSelectAll() {
+    if (!activitiesData) return;
+
+    for (const activity of activitiesData.activities) {
+        selectedActivityIds.add(activity.id);
+    }
+
+    // Update checkboxes
+    document.querySelectorAll('.activity-checkbox').forEach(cb => {
+        cb.checked = true;
+        cb.closest('.activity-item')?.classList.add('selected');
+    });
+
+    updateSelectionCount();
+}
+
+/**
+ * Handle deselect all button click
+ */
+function handleDeselectAll() {
+    selectedActivityIds.clear();
+
+    // Update checkboxes
+    document.querySelectorAll('.activity-checkbox').forEach(cb => {
+        cb.checked = false;
+        cb.closest('.activity-item')?.classList.remove('selected');
+    });
+
+    updateSelectionCount();
+}
+
+/**
+ * Close the activity selection dialog
+ */
+function closeActivityDialog() {
+    const dialog = document.getElementById('activity-selection-dialog');
+    dialog.close();
+}
+
+/**
+ * Handle confirm sync button click
+ * Starts sync with selected activities
+ */
+async function handleConfirmSync() {
+    console.log('Confirm sync clicked, selected activities:', [...selectedActivityIds]);
+
+    // Close the dialog
+    closeActivityDialog();
+
+    // Get selected activity IDs as array
+    const selectedIds = [...selectedActivityIds];
+
+    if (selectedIds.length === 0) {
+        showInfo('Aucune activite selectionnee', 'Veuillez selectionner au moins une activite a synchroniser.');
+        return;
+    }
+
+    // Perform the sync with selected activities
+    await performSync(selectedIds);
+}
+
+/**
+ * Perform synchronization with the backend
+ * @param {string[]} selectedActivityIds - Array of activity IDs to sync
+ */
+async function performSync(selectedActivityIds) {
+    console.log('Sync initiated with', selectedActivityIds.length, 'activities...');
+
+    const syncBtn = document.getElementById('sync-btn');
 
     // Disable button and show loading state using Pico CSS aria-busy attribute
     syncBtn.disabled = true;
@@ -380,17 +616,20 @@ async function handleSync() {
 
     // Reset progress
     document.getElementById('sync-progress-fill').style.width = '0%';
-    document.getElementById('progress-text').textContent = 'Démarrage...';
+    document.getElementById('progress-text').textContent = 'Demarrage...';
     document.getElementById('current-file').textContent = '';
 
     try {
-        // Start sync with current configuration
-        const stats = await invoke('start_sync', { config });
+        // Start sync with current configuration and selected activity IDs
+        const stats = await invoke('start_sync', {
+            config,
+            selectedActivityIds: selectedActivityIds
+        });
 
         console.log('Sync completed successfully:', stats);
 
         // Show success notification with stats
-        const successMsg = `${stats.downloaded} fichiers téléchargés, ${stats.skipped} ignorés${stats.failed > 0 ? `, ${stats.failed} en échec` : ', aucun échec'}`;
+        const successMsg = `${stats.downloaded} fichiers telecharges, ${stats.skipped} ignores${stats.failed > 0 ? `, ${stats.failed} en echec` : ', aucun echec'}`;
         showSuccess(successMsg);
     } catch (error) {
         console.error('Sync failed:', error);
@@ -403,6 +642,15 @@ async function handleSync() {
         syncBtn.removeAttribute('aria-busy');
         syncBtn.textContent = originalText;
     }
+}
+
+/**
+ * Escape HTML to prevent XSS
+ */
+function escapeHtml(text) {
+    const div = document.createElement('div');
+    div.textContent = text;
+    return div.innerHTML;
 }
 
 // Initialize when DOM is ready

--- a/src/styles.css
+++ b/src/styles.css
@@ -357,3 +357,203 @@ section button + button {
         flex-direction: column;
     }
 }
+
+
+/* ============================================
+   Issue #131: Activity Selection Dialog
+   ============================================ */
+
+#activity-selection-dialog {
+    max-width: 700px;
+    width: 90%;
+    max-height: 85vh;
+    padding: 0;
+    border: none;
+    border-radius: var(--pico-border-radius);
+    overflow: hidden;
+}
+
+#activity-selection-dialog::backdrop {
+    background: rgba(0, 0, 0, 0.5);
+}
+
+.activity-dialog-article {
+    margin: 0;
+    padding: 0;
+    display: flex;
+    flex-direction: column;
+    max-height: 85vh;
+}
+
+.activity-dialog-article header {
+    padding: 1rem 1.5rem;
+    margin: 0;
+    border-bottom: 1px solid var(--pico-muted-border-color);
+}
+
+.activity-dialog-article header h3 {
+    margin: 0;
+    font-size: 1.25rem;
+}
+
+.activity-dialog-controls {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    padding: 0.75rem 1.5rem;
+    background: var(--pico-card-background-color);
+    border-bottom: 1px solid var(--pico-muted-border-color);
+}
+
+.selection-controls {
+    display: flex;
+    gap: 0.5rem;
+}
+
+.selection-count {
+    font-size: 0.9rem;
+    color: var(--pico-muted-color);
+    font-style: italic;
+}
+
+.activity-list-container {
+    flex: 1;
+    overflow-y: auto;
+    padding: 0.5rem 0;
+    min-height: 200px;
+    max-height: 400px;
+}
+
+.activity-dialog-article footer {
+    padding: 1rem 1.5rem;
+    margin: 0;
+    border-top: 1px solid var(--pico-muted-border-color);
+    display: flex;
+    justify-content: flex-end;
+    gap: 0.75rem;
+}
+
+.activity-dialog-article footer button {
+    margin: 0;
+}
+
+/* Activity Item Styling */
+.activity-item {
+    display: flex;
+    align-items: flex-start;
+    gap: 0.75rem;
+    padding: 0.75rem 1.5rem;
+    cursor: pointer;
+    transition: background-color 0.2s;
+    border-bottom: 1px solid var(--pico-muted-border-color);
+}
+
+.activity-item:last-child {
+    border-bottom: none;
+}
+
+.activity-item:hover {
+    background-color: var(--pico-card-sectioning-background-color);
+}
+
+.activity-item.selected {
+    background-color: rgba(var(--pico-primary-background-rgb, 26, 115, 232), 0.08);
+}
+
+.activity-checkbox {
+    margin: 0.25rem 0 0 0;
+    flex-shrink: 0;
+}
+
+.activity-info {
+    flex: 1;
+    min-width: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 0.25rem;
+}
+
+.activity-title {
+    font-weight: 500;
+    color: var(--pico-color);
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
+
+.activity-meta {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.5rem;
+    font-size: 0.85rem;
+    color: var(--pico-muted-color);
+}
+
+.activity-date {
+    font-weight: 500;
+}
+
+.activity-media-count {
+    color: var(--pico-muted-color);
+}
+
+.synced-badge,
+.new-badge {
+    font-size: 0.75rem;
+    padding: 0.1rem 0.4rem;
+    border-radius: 3px;
+    font-weight: 500;
+}
+
+.synced-badge {
+    background-color: rgba(16, 185, 129, 0.15);
+    color: #10b981;
+}
+
+.new-badge {
+    background-color: rgba(59, 130, 246, 0.15);
+    color: #3b82f6;
+}
+
+.no-activities,
+.loading-text {
+    text-align: center;
+    padding: 2rem;
+    color: var(--pico-muted-color);
+    font-style: italic;
+}
+
+/* Responsive adjustments for activity dialog */
+@media (max-width: 600px) {
+    #activity-selection-dialog {
+        width: 95%;
+        max-height: 90vh;
+    }
+
+    .activity-dialog-controls {
+        flex-direction: column;
+        gap: 0.5rem;
+        align-items: stretch;
+    }
+
+    .selection-controls {
+        justify-content: center;
+    }
+
+    .selection-count {
+        text-align: center;
+    }
+
+    .activity-meta {
+        flex-direction: column;
+        gap: 0.25rem;
+    }
+
+    .activity-dialog-article footer {
+        flex-direction: column;
+    }
+
+    .activity-dialog-article footer button {
+        width: 100%;
+    }
+}


### PR DESCRIPTION
## Summary

Add activity selection dialog that lets users choose which activities to synchronize instead of the previous all-or-nothing approach.

- When clicking "Synchroniser", a dialog now shows all available activities with checkboxes
- Previously synced activities and new activities are pre-selected by default
- Users can select/deselect individual activities or use "Select All"/"Deselect All" buttons
- Synced activity IDs are persisted to track selections for subsequent syncs

## Changes

### Backend (Rust/Tauri)
- Add `SyncState` struct to persist previously synced activity IDs
- Add `fetch_activities` Tauri command to get activities without syncing
- Modify `start_sync` to accept optional `selected_activity_ids` parameter
- Add sync state persistence to `sync_state.json` in app data directory

### Frontend (HTML/CSS/JavaScript)
- Add activity selection dialog with checkboxes and badges
- Show "Déjà synchronisé" badge for previously synced activities
- Show "Nouveau" badge for new activities
- Display activity title, date, and media count
- Add selection controls (Select All / Deselect All)
- Pre-select previously synced + new activities by default

## Test plan
- [ ] First sync: All activities should be selected by default
- [ ] Subsequent syncs: Previously synced + new activities should be pre-selected
- [ ] Deselecting an activity should exclude it from sync
- [ ] Sync state should persist across app restarts
- [ ] Cancel button should close dialog without syncing
- [ ] Empty selection should disable confirm button

Closes #131